### PR TITLE
BPMN Errors + Messages

### DIFF
--- a/src/bpmn-properties-panel/entries/ReferenceSelect.js
+++ b/src/bpmn-properties-panel/entries/ReferenceSelect.js
@@ -1,0 +1,43 @@
+import {
+  useEffect
+} from 'preact/hooks';
+
+import {
+  query as domQuery
+} from 'min-dom';
+
+import {
+  usePrevious
+} from '../../properties-panel/hooks';
+
+import SelectEntry from '../../properties-panel/components/entries/Select';
+
+
+export default function ReferenceSelectEntry(props) {
+  const {
+    autoFocusEntry,
+    element,
+    getOptions
+  } = props;
+
+  const options = getOptions(element);
+  const prevOptions = usePrevious(options);
+
+  // auto focus specifc other entry when options changed
+  useEffect(() => {
+    if (autoFocusEntry && prevOptions && options.length > prevOptions.length) {
+
+      const entry = domQuery(`[data-entry-id="${autoFocusEntry}"]`);
+
+      const focusableInput = domQuery('.bio-properties-panel-input', entry);
+
+      if (focusableInput) {
+        focusableInput.select();
+      }
+    }
+  }, [ options ]);
+
+  return (
+    <SelectEntry { ...props } />
+  );
+}

--- a/src/bpmn-properties-panel/provider/bpmn/BpmnPropertiesProvider.js
+++ b/src/bpmn-properties-panel/provider/bpmn/BpmnPropertiesProvider.js
@@ -1,12 +1,17 @@
 import Group from '../../../properties-panel/components/Group';
 
 import {
-  NameProperty,
-  IdProperty,
+  DocumentationProps,
+  ErrorProps,
   ExecutableProperty,
+  IdProperty,
+  NameProperty,
   ProcessProps,
-  DocumentationProps
 } from './properties';
+
+import {
+  isErrorSupported
+} from './utils/EventDefinitionUtil';
 
 function GeneralGroup(element) {
 
@@ -50,12 +55,31 @@ function DocumentationGroup(element) {
 
 }
 
+function ErrorGroup(element) {
+
+  const entries = [
+    ...ErrorProps({ element })
+  ];
+
+  return {
+    id: 'error',
+    label: 'Error',
+    entries,
+    component: Group
+  };
+
+}
+
 function getGroups(element) {
 
   const groups = [
     GeneralGroup(element),
     DocumentationGroup(element)
   ];
+
+  if (isErrorSupported(element)) {
+    groups.push(ErrorGroup(element));
+  }
 
   return groups;
 }

--- a/src/bpmn-properties-panel/provider/bpmn/BpmnPropertiesProvider.js
+++ b/src/bpmn-properties-panel/provider/bpmn/BpmnPropertiesProvider.js
@@ -5,12 +5,14 @@ import {
   ErrorProps,
   ExecutableProperty,
   IdProperty,
+  MessageProps,
   NameProperty,
   ProcessProps,
 } from './properties';
 
 import {
-  isErrorSupported
+  isErrorSupported,
+  isMessageSupported
 } from './utils/EventDefinitionUtil';
 
 function GeneralGroup(element) {
@@ -70,6 +72,21 @@ function ErrorGroup(element) {
 
 }
 
+function MessageGroup(element) {
+
+  const entries = [
+    ...MessageProps({ element })
+  ];
+
+  return {
+    id: 'message',
+    label: 'Message',
+    entries,
+    component: Group
+  };
+
+}
+
 function getGroups(element) {
 
   const groups = [
@@ -79,6 +96,10 @@ function getGroups(element) {
 
   if (isErrorSupported(element)) {
     groups.push(ErrorGroup(element));
+  }
+
+  if (isMessageSupported(element)) {
+    groups.push(MessageGroup(element));
   }
 
   return groups;

--- a/src/bpmn-properties-panel/provider/bpmn/properties/ErrorProps.js
+++ b/src/bpmn-properties-panel/provider/bpmn/properties/ErrorProps.js
@@ -7,7 +7,7 @@ import {
 } from 'min-dash';
 
 import TextField from '../../../../properties-panel/components/entries/TextField';
-import Select from '../../../../properties-panel/components/entries/Select';
+import ReferenceSelect from '../../../entries/ReferenceSelect';
 
 import {
   useService
@@ -116,7 +116,7 @@ function ErrorRef(props) {
 
     let options = [
       { value: '', label: translate('<none>') },
-      { value: CREATE_NEW_OPTION, label: translate('Create new') }
+      { value: CREATE_NEW_OPTION, label: translate('Create new ...') }
     ];
 
     const errors = findRootElementsByType(getBusinessObject(element), 'bpmn:Error');
@@ -131,10 +131,11 @@ function ErrorRef(props) {
     return options;
   };
 
-  return Select({
+  return ReferenceSelect({
     element,
     id: 'errorRef',
     label: translate('Global Error Reference'),
+    autoFocusEntry: 'errorName',
     getValue,
     setValue,
     getOptions

--- a/src/bpmn-properties-panel/provider/bpmn/properties/ErrorProps.js
+++ b/src/bpmn-properties-panel/provider/bpmn/properties/ErrorProps.js
@@ -1,0 +1,221 @@
+import {
+  getBusinessObject
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import {
+  sortBy
+} from 'min-dash';
+
+import TextField from '../../../../properties-panel/components/entries/TextField';
+import Select from '../../../../properties-panel/components/entries/Select';
+
+import {
+  useService
+} from '../../../hooks';
+
+import {
+  getError,
+  getErrorEventDefinition
+} from '../utils/EventDefinitionUtil';
+
+import {
+  createElement,
+  findElementById,
+  findRootElementsByType,
+  getRoot,
+  nextId
+} from '../utils/ElementUtil';
+
+const CREATE_NEW_OPTION = 'create-new';
+
+
+export function ErrorProps(props) {
+  const {
+    element
+  } = props;
+
+  const error = getError(element);
+
+  let entries = [
+    { id: 'errorRef', component: <ErrorRef element={ element } /> }
+  ];
+
+  if (error) {
+    entries = [
+      ...entries,
+      { id: 'errorName', component: <ErrorName element={ element } /> },
+      { id: 'errorCode', component: <ErrorCode element={ element } /> }
+    ];
+  }
+
+  return entries;
+}
+
+function ErrorRef(props) {
+  const { element } = props;
+
+  const bpmnFactory = useService('bpmnFactory');
+  const commandStack = useService('commandStack');
+  const translate = useService('translate');
+
+  const errorEventDefinition = getErrorEventDefinition(element);
+
+  const getValue = () => {
+    const error = getError(element);
+
+    return error && error.get('id');
+  };
+
+  const setValue = (value) => {
+    const root = getRoot(errorEventDefinition);
+    const commands = [];
+
+    let error;
+
+    // (1) create new error
+    if (value === CREATE_NEW_OPTION) {
+      error = createElement(
+        'bpmn:Error',
+        { name: nextId('Error_') },
+        root,
+        bpmnFactory
+      );
+
+      value = error.get('id');
+
+      commands.push({
+        cmd: 'properties-panel.update-businessobject-list',
+        context: {
+          element,
+          currentObject: root,
+          propertyName: 'rootElements',
+          objectsToAdd: [ error ]
+        }
+      });
+    }
+
+    // (2) update (or remove) errorRef
+    error = error || findElementById(errorEventDefinition, 'bpmn:Error', value);
+
+    commands.push({
+      cmd: 'properties-panel.update-businessobject',
+      context: {
+        element,
+        businessObject: errorEventDefinition,
+        properties: {
+          errorRef: error
+        }
+      }
+    });
+
+    // (3) commit all updates
+    return commandStack.execute('properties-panel.multi-command-executor', commands);
+  };
+
+  const getOptions = () => {
+
+    let options = [
+      { value: '', label: translate('<none>') },
+      { value: CREATE_NEW_OPTION, label: translate('Create new') }
+    ];
+
+    const errors = findRootElementsByType(getBusinessObject(element), 'bpmn:Error');
+
+    sortByName(errors).forEach(error => {
+      options.push({
+        value: error.get('id'),
+        label: error.get('name')
+      });
+    });
+
+    return options;
+  };
+
+  return Select({
+    element,
+    id: 'errorRef',
+    label: translate('Global Error Reference'),
+    getValue,
+    setValue,
+    getOptions
+  });
+}
+
+function ErrorName(props) {
+  const { element } = props;
+
+  const commandStack = useService('commandStack');
+  const translate = useService('translate');
+  const debounce = useService('debounceInput');
+
+  const error = getError(element);
+
+  const getValue = () => {
+    return error.get('name');
+  };
+
+  const setValue = (value) => {
+    return commandStack.execute(
+      'properties-panel.update-businessobject',
+      {
+        element,
+        businessObject: error,
+        properties: {
+          name: value
+        }
+      }
+    );
+  };
+
+  return TextField({
+    element,
+    id: 'errorName',
+    label: translate('Name'),
+    getValue,
+    setValue,
+    debounce
+  });
+}
+
+function ErrorCode(props) {
+  const { element } = props;
+
+  const commandStack = useService('commandStack');
+  const translate = useService('translate');
+  const debounce = useService('debounceInput');
+
+  const error = getError(element);
+
+  const getValue = () => {
+    return error.get('errorCode');
+  };
+
+  const setValue = (value) => {
+    return commandStack.execute(
+      'properties-panel.update-businessobject',
+      {
+        element,
+        businessObject: error,
+        properties: {
+          errorCode: value
+        }
+      }
+    );
+  };
+
+  return TextField({
+    element,
+    id: 'errorCode',
+    label: translate('Code'),
+    getValue,
+    setValue,
+    debounce
+  });
+}
+
+
+// helper /////////////////////////
+
+function sortByName(elements) {
+  return sortBy(elements, e => e.name.toLowerCase());
+}

--- a/src/bpmn-properties-panel/provider/bpmn/properties/MessageProps.js
+++ b/src/bpmn-properties-panel/provider/bpmn/properties/MessageProps.js
@@ -1,0 +1,184 @@
+import {
+  getBusinessObject
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import {
+  sortBy
+} from 'min-dash';
+
+import TextField from '../../../../properties-panel/components/entries/TextField';
+import Select from '../../../../properties-panel/components/entries/Select';
+
+import {
+  useService
+} from '../../../hooks';
+
+import {
+  getMessage,
+  getMessageEventDefinition
+} from '../utils/EventDefinitionUtil';
+
+import {
+  createElement,
+  findElementById,
+  findRootElementsByType,
+  getRoot,
+  nextId
+} from '../utils/ElementUtil';
+
+const CREATE_NEW_OPTION = 'create-new';
+
+
+export function MessageProps(props) {
+  const {
+    element
+  } = props;
+
+  const message = getMessage(element);
+
+  let entries = [
+    { id: 'messageRef', component: <MessageRef element={ element } /> }
+  ];
+
+  if (message) {
+    entries = [
+      ...entries,
+      { id: 'messageName', component: <MessageName element={ element } /> },
+    ];
+  }
+
+  return entries;
+}
+
+function MessageRef(props) {
+  const { element } = props;
+
+  const bpmnFactory = useService('bpmnFactory');
+  const commandStack = useService('commandStack');
+  const translate = useService('translate');
+
+  const messageEventDefinition = getMessageEventDefinition(element);
+
+  const getValue = () => {
+    const message = getMessage(element);
+
+    return message && message.get('id');
+  };
+
+  const setValue = (value) => {
+    const root = getRoot(messageEventDefinition);
+    const commands = [];
+
+    let message;
+
+    // (1) create new message
+    if (value === CREATE_NEW_OPTION) {
+      message = createElement(
+        'bpmn:Message',
+        { name: nextId('Message_') },
+        root,
+        bpmnFactory
+      );
+
+      value = message.get('id');
+
+      commands.push({
+        cmd: 'properties-panel.update-businessobject-list',
+        context: {
+          element,
+          currentObject: root,
+          propertyName: 'rootElements',
+          objectsToAdd: [ message ]
+        }
+      });
+    }
+
+    // (2) update (or remove) messageRef
+    message = message || findElementById(messageEventDefinition, 'bpmn:Message', value);
+
+    commands.push({
+      cmd: 'properties-panel.update-businessobject',
+      context: {
+        element,
+        businessObject: messageEventDefinition,
+        properties: {
+          messageRef: message
+        }
+      }
+    });
+
+    // (3) commit all updates
+    return commandStack.execute('properties-panel.multi-command-executor', commands);
+  };
+
+  const getOptions = () => {
+
+    let options = [
+      { value: '', label: translate('<none>') },
+      { value: CREATE_NEW_OPTION, label: translate('Create new') }
+    ];
+
+    const messages = findRootElementsByType(getBusinessObject(element), 'bpmn:Message');
+
+    sortByName(messages).forEach(message => {
+      options.push({
+        value: message.get('id'),
+        label: message.get('name')
+      });
+    });
+
+    return options;
+  };
+
+  return Select({
+    element,
+    id: 'messageRef',
+    label: translate('Global Message Reference'),
+    getValue,
+    setValue,
+    getOptions
+  });
+}
+
+function MessageName(props) {
+  const { element } = props;
+
+  const commandStack = useService('commandStack');
+  const translate = useService('translate');
+  const debounce = useService('debounceInput');
+
+  const message = getMessage(element);
+
+  const getValue = () => {
+    return message.get('name');
+  };
+
+  const setValue = (value) => {
+    return commandStack.execute(
+      'properties-panel.update-businessobject',
+      {
+        element,
+        businessObject: message,
+        properties: {
+          name: value
+        }
+      }
+    );
+  };
+
+  return TextField({
+    element,
+    id: 'messageName',
+    label: translate('Name'),
+    getValue,
+    setValue,
+    debounce
+  });
+}
+
+
+// helper /////////////////////////
+
+function sortByName(elements) {
+  return sortBy(elements, e => e.name.toLowerCase());
+}

--- a/src/bpmn-properties-panel/provider/bpmn/properties/MessageProps.js
+++ b/src/bpmn-properties-panel/provider/bpmn/properties/MessageProps.js
@@ -7,7 +7,7 @@ import {
 } from 'min-dash';
 
 import TextField from '../../../../properties-panel/components/entries/TextField';
-import Select from '../../../../properties-panel/components/entries/Select';
+import ReferenceSelect from '../../../entries/ReferenceSelect';
 
 import {
   useService
@@ -73,9 +73,11 @@ function MessageRef(props) {
 
     // (1) create new message
     if (value === CREATE_NEW_OPTION) {
+      const id = nextId('Message_');
+
       message = createElement(
         'bpmn:Message',
-        { name: nextId('Message_') },
+        { id, name: id },
         root,
         bpmnFactory
       );
@@ -115,7 +117,7 @@ function MessageRef(props) {
 
     let options = [
       { value: '', label: translate('<none>') },
-      { value: CREATE_NEW_OPTION, label: translate('Create new') }
+      { value: CREATE_NEW_OPTION, label: translate('Create new ...') }
     ];
 
     const messages = findRootElementsByType(getBusinessObject(element), 'bpmn:Message');
@@ -130,10 +132,11 @@ function MessageRef(props) {
     return options;
   };
 
-  return Select({
+  return ReferenceSelect({
     element,
     id: 'messageRef',
     label: translate('Global Message Reference'),
+    autoFocusEntry: 'messageName',
     getValue,
     setValue,
     getOptions

--- a/src/bpmn-properties-panel/provider/bpmn/properties/index.js
+++ b/src/bpmn-properties-panel/provider/bpmn/properties/index.js
@@ -3,3 +3,4 @@ export { default as IdProperty } from './Id';
 export { default as NameProperty } from './Name';
 export { DocumentationProps } from './DocumentationProps';
 export { ProcessProps } from './ProcessProps';
+export { ErrorProps } from './ErrorProps';

--- a/src/bpmn-properties-panel/provider/bpmn/properties/index.js
+++ b/src/bpmn-properties-panel/provider/bpmn/properties/index.js
@@ -4,3 +4,4 @@ export { default as NameProperty } from './Name';
 export { DocumentationProps } from './DocumentationProps';
 export { ProcessProps } from './ProcessProps';
 export { ErrorProps } from './ErrorProps';
+export { MessageProps } from './MessageProps';

--- a/src/bpmn-properties-panel/provider/bpmn/utils/ElementUtil.js
+++ b/src/bpmn-properties-panel/provider/bpmn/utils/ElementUtil.js
@@ -1,0 +1,53 @@
+import Ids from 'ids';
+
+import {
+  is
+} from 'bpmn-js/lib/util/ModelUtil';
+
+/**
+ * Creates a new element and set the parent to it
+ *
+ * @param {String} elementType of the new element
+ * @param {Object} properties of the new element in key-value pairs
+ * @param {moddle.object} parent of the new element
+ * @param {BpmnFactory} factory which creates the new element
+ *
+ * @returns {djs.model.Base} element which is created
+ */
+export function createElement(elementType, properties, parent, factory) {
+  const element = factory.create(elementType, properties);
+  element.$parent = parent;
+
+  return element;
+}
+
+export function nextId(prefix) {
+  const ids = new Ids([32,32,1]);
+
+  return ids.nextPrefixed(prefix);
+}
+
+export function getRoot(businessObject) {
+  let parent = businessObject;
+
+  while (parent.$parent) {
+    parent = parent.$parent;
+  }
+
+  return parent;
+}
+
+export function filterElementsByType(objectList, type) {
+  const list = objectList || [];
+  return list.filter(element => is(element, type));
+}
+
+export function findRootElementsByType(businessObject, referencedType) {
+  const root = getRoot(businessObject);
+  return filterElementsByType(root.get('rootElements'), referencedType);
+}
+
+export function findElementById(eventDefinition, type, id) {
+  const elements = findRootElementsByType(eventDefinition, type);
+  return elements.find(element => element.id === id);
+}

--- a/src/bpmn-properties-panel/provider/bpmn/utils/EventDefinitionUtil.js
+++ b/src/bpmn-properties-panel/provider/bpmn/utils/EventDefinitionUtil.js
@@ -38,3 +38,29 @@ export function getEventDefinition(element, eventType) {
     return is(definition, eventType);
   });
 }
+
+export function isMessageSupported(element) {
+  return is(element, 'bpmn:ReceiveTask') || (
+    isAny(element, [
+      'bpmn:StartEvent',
+      'bpmn:EndEvent',
+      'bpmn:IntermediateThrowEvent',
+      'bpmn:BoundaryEvent',
+      'bpmn:IntermediateCatchEvent'
+    ]) && !!getMessageEventDefinition(element)
+  );
+}
+
+export function getMessageEventDefinition(element) {
+  if (is(element, 'bpmn:ReceiveTask')) {
+    return getBusinessObject(element);
+  }
+
+  return getEventDefinition(element, 'bpmn:MessageEventDefinition');
+}
+
+export function getMessage(element) {
+  const messageEventDefinition = getMessageEventDefinition(element);
+
+  return messageEventDefinition && messageEventDefinition.get('messageRef');
+}

--- a/src/bpmn-properties-panel/provider/bpmn/utils/EventDefinitionUtil.js
+++ b/src/bpmn-properties-panel/provider/bpmn/utils/EventDefinitionUtil.js
@@ -1,0 +1,40 @@
+import {
+  isAny
+} from 'bpmn-js/lib/features/modeling/util/ModelingUtil';
+
+import {
+  getBusinessObject,
+  is
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import {
+  find
+} from 'min-dash';
+
+export function isErrorSupported(element) {
+  return isAny(element, [
+    'bpmn:StartEvent',
+    'bpmn:BoundaryEvent',
+    'bpmn:EndEvent'
+  ]) && !!getErrorEventDefinition(element);
+}
+
+export function getErrorEventDefinition(element) {
+  return getEventDefinition(element, 'bpmn:ErrorEventDefinition');
+}
+
+export function getError(element) {
+  const errorEventDefinition = getErrorEventDefinition(element);
+
+  return errorEventDefinition && errorEventDefinition.get('errorRef');
+}
+
+export function getEventDefinition(element, eventType) {
+  const businessObject = getBusinessObject(element);
+
+  const eventDefinitions = businessObject.get('eventDefinitions') || [];
+
+  return find(eventDefinitions, function(definition) {
+    return is(definition, eventType);
+  });
+}

--- a/src/properties-panel/components/entries/Select.js
+++ b/src/properties-panel/components/entries/Select.js
@@ -1,3 +1,17 @@
+/**
+ * @typedef { { value: String, label: String } } Option
+ */
+
+/**
+ * Provides basic select input.
+ *
+ * @param {Object} props
+ * @param {String} props.id
+ * @param {String} props.label
+ * @param {Function} props.onChange
+ * @param {Array<Option>} [props.options]
+ * @param {String} props.value
+ */
 function Select(props) {
   const {
     id,

--- a/src/properties-panel/components/entries/Select.js
+++ b/src/properties-panel/components/entries/Select.js
@@ -28,13 +28,13 @@ function Select(props) {
   return (
     <div class="bio-properties-panel-select">
       <label for={ prefixId(id) } class="bio-properties-panel-label">{ label }</label>
-      <select id={ prefixId(id) } name={ id } class="bio-properties-panel-input" onInput={ handleChange }>
+      <select id={ prefixId(id) } name={ id } class="bio-properties-panel-input" onInput={ handleChange } value={ value }>
         {
-          options.map((option) => {
+          options.map((option, idx) => {
             return (
               <option
-                value={ option.value }
-                selected={ option.value === value }>
+                key={ idx }
+                value={ option.value }>
                 { option.label }
               </option>
             );

--- a/test/spec/bpmn-properties-panel/provider/bpmn/BpmnPropertiesProvider.bpmn
+++ b/test/spec/bpmn-properties-panel/provider/bpmn/BpmnPropertiesProvider.bpmn
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1jjb961" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1">
+  <bpmn:process id="Process_1j5bpos" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" />
+    <bpmn:task id="Task_1" />
+    <bpmn:boundaryEvent id="BoundaryEvent_1" attachedToRef="Task_1">
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_0rixkva" />
+    </bpmn:boundaryEvent>
+    <bpmn:startEvent id="MessageEvent_1">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1j4k787" />
+    </bpmn:startEvent>
+    <bpmn:receiveTask id="ReceiveTask_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1j5bpos">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0hzk0s5_di" bpmnElement="Task_1">
+        <dc:Bounds x="290" y="110" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0axv63h_di" bpmnElement="MessageEvent_1">
+        <dc:Bounds x="212" y="252" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_17nav0i_di" bpmnElement="ReceiveTask_1">
+        <dc:Bounds x="360" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ej25yw_di" bpmnElement="BoundaryEvent_1">
+        <dc:Bounds x="322" y="172" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/bpmn-properties-panel/provider/bpmn/BpmnPropertiesProvider.spec.js
+++ b/test/spec/bpmn-properties-panel/provider/bpmn/BpmnPropertiesProvider.spec.js
@@ -93,6 +93,57 @@ describe('<BpmnPropertiesProvider>', function() {
     expect(errorGroup).to.exist;
   }));
 
+
+  it('should NOT show message group', inject(async function(elementRegistry, selection) {
+
+    // given
+    const startEvent = elementRegistry.get('StartEvent_1');
+
+    await act(() => {
+      selection.select(startEvent);
+    });
+
+    // when
+    const messageGroup = getGroup(container, 'message');
+
+    // then
+    expect(messageGroup).to.not.exist;
+  }));
+
+
+  it('should show message group', inject(async function(elementRegistry, selection) {
+
+    // given
+    const messageEvent = elementRegistry.get('MessageEvent_1');
+
+    await act(() => {
+      selection.select(messageEvent);
+    });
+
+    // when
+    const messageGroup = getGroup(container, 'message');
+
+    // then
+    expect(messageGroup).to.exist;
+  }));
+
+
+  it('should show message group - receive task', inject(async function(elementRegistry, selection) {
+
+    // given
+    const receiveTask = elementRegistry.get('ReceiveTask_1');
+
+    await act(() => {
+      selection.select(receiveTask);
+    });
+
+    // when
+    const messageGroup = getGroup(container, 'message');
+
+    // then
+    expect(messageGroup).to.exist;
+  }));
+
 });
 
 

--- a/test/spec/bpmn-properties-panel/provider/bpmn/BpmnPropertiesProvider.spec.js
+++ b/test/spec/bpmn-properties-panel/provider/bpmn/BpmnPropertiesProvider.spec.js
@@ -21,7 +21,7 @@ import BpmnPropertiesPanel from 'src/bpmn-properties-panel';
 
 import BpmnPropertiesProvider from 'src/bpmn-properties-panel/provider/bpmn';
 
-import diagramXML from 'test/fixtures/simple.bpmn';
+import diagramXML from './BpmnPropertiesProvider.bpmn';
 
 
 describe('<BpmnPropertiesProvider>', function() {
@@ -57,6 +57,40 @@ describe('<BpmnPropertiesProvider>', function() {
 
     // then
     expect(generalGroup).to.exist;
+  }));
+
+
+  it('should NOT show error group', inject(async function(elementRegistry, selection) {
+
+    // given
+    const startEvent = elementRegistry.get('StartEvent_1');
+
+    await act(() => {
+      selection.select(startEvent);
+    });
+
+    // when
+    const errorGroup = getGroup(container, 'error');
+
+    // then
+    expect(errorGroup).to.not.exist;
+  }));
+
+
+  it('should show error group', inject(async function(elementRegistry, selection) {
+
+    // given
+    const errorBoundaryEvent = elementRegistry.get('BoundaryEvent_1');
+
+    await act(() => {
+      selection.select(errorBoundaryEvent);
+    });
+
+    // when
+    const errorGroup = getGroup(container, 'error');
+
+    // then
+    expect(errorGroup).to.exist;
   }));
 
 });

--- a/test/spec/bpmn-properties-panel/provider/bpmn/ErrorProps.bpmn
+++ b/test/spec/bpmn-properties-panel/provider/bpmn/ErrorProps.bpmn
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0evowaa" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:process id="Process_0nlx8t6" isExecutable="true">
+    <bpmn:task id="Task_1" />
+    <bpmn:boundaryEvent id="ErrorEvent_empty" attachedToRef="Task_1">
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_1" />
+    </bpmn:boundaryEvent>
+    <bpmn:subProcess id="EventSubProcess_1" triggeredByEvent="true">
+      <bpmn:startEvent id="ErrorEvent_1">
+        <bpmn:errorEventDefinition id="ErrorEventDefinition_2" errorRef="Error_1" />
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:startEvent id="StartEvent_1" />
+  </bpmn:process>
+  <bpmn:error id="Error_1" name="Error_1" errorCode="500" />
+  <bpmn:error id="Error_3" name="Error_3" />
+  <bpmn:error id="Error_2" name="Error_2" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0nlx8t6">
+      <bpmndi:BPMNShape id="Activity_0m22viw_di" bpmnElement="Task_1">
+        <dc:Bounds x="530" y="340" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0mlb230_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="242" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0nnog6x_di" bpmnElement="EventSubProcess_1" isExpanded="true">
+        <dc:Bounds x="120" y="290" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1f72hoo_di" bpmnElement="ErrorEvent_1">
+        <dc:Bounds x="160" y="372" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1276rgr_di" bpmnElement="ErrorEvent_empty">
+        <dc:Bounds x="552" y="402" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/bpmn-properties-panel/provider/bpmn/ErrorProps.spec.js
+++ b/test/spec/bpmn-properties-panel/provider/bpmn/ErrorProps.spec.js
@@ -1,0 +1,374 @@
+import TestContainer from 'mocha-test-container-support';
+import { act } from '@testing-library/preact';
+
+import {
+  bootstrapPropertiesPanel,
+  changeInput,
+  inject
+} from 'test/TestHelper';
+
+import {
+  query as domQuery,
+  queryAll as domQueryAll
+} from 'min-dom';
+
+import CoreModule from 'bpmn-js/lib/core';
+import SelectionModule from 'diagram-js/lib/features/selection';
+import ModelingModule from 'bpmn-js/lib/features/modeling';
+
+import BpmnPropertiesPanel from 'src/bpmn-properties-panel';
+
+import BpmnPropertiesProvider from 'src/bpmn-properties-panel/provider/bpmn';
+
+import {
+  getError
+} from 'src/bpmn-properties-panel/provider/bpmn/utils/EventDefinitionUtil';
+
+import diagramXML from './ErrorProps.bpmn';
+
+
+describe('provider/bpmn - ErrorProps', function() {
+
+  const testModules = [
+    CoreModule,
+    SelectionModule,
+    ModelingModule,
+    BpmnPropertiesPanel,
+    BpmnPropertiesProvider
+  ];
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  beforeEach(bootstrapPropertiesPanel(diagramXML, {
+    modules: testModules,
+    debounceInput: false
+  }));
+
+
+  describe('bpmn:StartEvent#errorRef', function() {
+
+    it('should NOT be displayed for normal start event',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('StartEvent_1');
+
+        // when
+        await act(() => {
+          selection.select(startEvent);
+        });
+
+        // then
+        const errorRefSelect = domQuery('select[name=errorRef]', container);
+
+        expect(errorRefSelect).to.be.null;
+      })
+    );
+
+
+    it('should display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const errorEvent = elementRegistry.get('ErrorEvent_1');
+
+      await act(() => {
+        selection.select(errorEvent);
+      });
+
+      // when
+      const errorRefSelect = domQuery('select[name=errorRef]', container);
+
+      // then
+      expect(errorRefSelect.value).to.eql(getError(errorEvent).get('id'));
+    }));
+
+
+    it('should display select options in correct order', inject(async function(elementRegistry, selection) {
+
+      // given
+      const errorEvent = elementRegistry.get('ErrorEvent_1');
+
+      await act(() => {
+        selection.select(errorEvent);
+      });
+
+      // when
+      const errorRefSelect = domQuery('select[name=errorRef]', container);
+
+      // then
+      expect(asOptionNamesList(errorRefSelect)).to.eql([
+        '<none>',
+        'Create new',
+        'Error_1',
+        'Error_2',
+        'Error_3'
+      ]);
+    }));
+
+
+    it('should update', inject(async function(elementRegistry, selection) {
+
+      // given
+      const errorEvent = elementRegistry.get('ErrorEvent_1');
+
+      await act(() => {
+        selection.select(errorEvent);
+      });
+
+      // when
+      const errorRefSelect = domQuery('select[name=errorRef]', container);
+      changeInput(errorRefSelect, 'Error_2');
+
+      // then
+      expect(getError(errorEvent).get('id')).to.eql('Error_2');
+    }));
+
+
+    it('should create new error', inject(async function(elementRegistry, selection) {
+
+      // given
+      const errorEvent = elementRegistry.get('ErrorEvent_empty');
+
+      await act(() => {
+        selection.select(errorEvent);
+      });
+
+      // assume
+      expect(getError(errorEvent)).to.not.exist;
+
+      // when
+      const errorRefSelect = domQuery('select[name=errorRef]', container);
+      changeInput(errorRefSelect, 'create-new');
+
+      // then
+      expect(getError(errorEvent)).to.exist;
+    }));
+
+
+    it('should remove error reference', inject(async function(elementRegistry, selection) {
+
+      // given
+      const errorEvent = elementRegistry.get('ErrorEvent_1');
+
+      await act(() => {
+        selection.select(errorEvent);
+      });
+
+      // assume
+      expect(getError(errorEvent)).to.exist;
+
+      // when
+      const errorRefSelect = domQuery('select[name=errorRef]', container);
+      changeInput(errorRefSelect, '');
+
+      // then
+      expect(getError(errorEvent)).to.not.exist;
+    }));
+
+
+    it('should update on external change',
+      inject(async function(elementRegistry, selection, commandStack) {
+
+        // given
+        const errorEvent = elementRegistry.get('ErrorEvent_1');
+        const originalValue = getError(errorEvent).get('id');
+
+        await act(() => {
+          selection.select(errorEvent);
+        });
+        const errorRefSelect = domQuery('select[name=errorRef]', container);
+        changeInput(errorRefSelect, 'Error_2');
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        // then
+        expect(errorRefSelect.value).to.eql(originalValue);
+      })
+    );
+
+  });
+
+
+  describe('bpmn:StartEvent#errorRef.name', function() {
+
+    it('should NOT be displayed for normal start event',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('StartEvent_1');
+
+        // when
+        await act(() => {
+          selection.select(startEvent);
+        });
+
+        // then
+        const errorNameInput = domQuery('input[name=errorName]', container);
+
+        expect(errorNameInput).to.be.null;
+      })
+    );
+
+
+    it('should display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const errorEvent = elementRegistry.get('ErrorEvent_1');
+
+      await act(() => {
+        selection.select(errorEvent);
+      });
+
+      // when
+      const errorNameInput = domQuery('input[name=errorName]', container);
+
+      // then
+      expect(errorNameInput.value).to.eql(getError(errorEvent).get('name'));
+    }));
+
+
+    it('should update', inject(async function(elementRegistry, selection) {
+
+      // given
+      const errorEvent = elementRegistry.get('ErrorEvent_1');
+
+      await act(() => {
+        selection.select(errorEvent);
+      });
+
+      // when
+      const errorNameInput = domQuery('input[name=errorName]', container);
+      changeInput(errorNameInput, 'newValue');
+
+      // then
+      expect(getError(errorEvent).get('name')).to.eql('newValue');
+    }));
+
+
+    it('should update on external change',
+      inject(async function(elementRegistry, selection, commandStack) {
+
+        // given
+        const errorEvent = elementRegistry.get('ErrorEvent_1');
+        const originalValue = getError(errorEvent).get('name');
+
+        await act(() => {
+          selection.select(errorEvent);
+        });
+        const errorNameInput = domQuery('input[name=errorName]', container);
+        changeInput(errorNameInput, 'newValue');
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        // then
+        expect(errorNameInput.value).to.eql(originalValue);
+      })
+    );
+
+  });
+
+
+  describe('bpmn:StartEvent#errorRef.code', function() {
+
+    it('should NOT be displayed for normal start event',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('StartEvent_1');
+
+        // when
+        await act(() => {
+          selection.select(startEvent);
+        });
+
+        // then
+        const errorCodeInput = domQuery('input[name=errorCode]', container);
+
+        expect(errorCodeInput).to.be.null;
+      })
+    );
+
+
+    it('should display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const errorEvent = elementRegistry.get('ErrorEvent_1');
+
+      await act(() => {
+        selection.select(errorEvent);
+      });
+
+      // when
+      const errorCodeInput = domQuery('input[name=errorCode]', container);
+
+      // then
+      expect(errorCodeInput.value).to.eql(getError(errorEvent).get('errorCode'));
+    }));
+
+
+    it('should update', inject(async function(elementRegistry, selection) {
+
+      // given
+      const errorEvent = elementRegistry.get('ErrorEvent_1');
+
+      await act(() => {
+        selection.select(errorEvent);
+      });
+
+      // when
+      const errorCodeInput = domQuery('input[name=errorCode]', container);
+      changeInput(errorCodeInput, 'newValue');
+
+      // then
+      expect(getError(errorEvent).get('errorCode')).to.eql('newValue');
+    }));
+
+
+    it('should update on external change',
+      inject(async function(elementRegistry, selection, commandStack) {
+
+        // given
+        const errorEvent = elementRegistry.get('ErrorEvent_1');
+        const originalValue = getError(errorEvent).get('errorCode');
+
+        await act(() => {
+          selection.select(errorEvent);
+        });
+        const errorCodeInput = domQuery('input[name=errorCode]', container);
+        changeInput(errorCodeInput, 'newValue');
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        // then
+        expect(errorCodeInput.value).to.eql(originalValue);
+      })
+    );
+
+  });
+
+});
+
+
+// helper ///////////////
+
+function asOptionNamesList(select) {
+  const names = [];
+  const options = domQueryAll('option', select);
+
+  options.forEach(o => names.push(o.label));
+
+  return names;
+}

--- a/test/spec/bpmn-properties-panel/provider/bpmn/ErrorProps.spec.js
+++ b/test/spec/bpmn-properties-panel/provider/bpmn/ErrorProps.spec.js
@@ -102,7 +102,7 @@ describe('provider/bpmn - ErrorProps', function() {
       // then
       expect(asOptionNamesList(errorRefSelect)).to.eql([
         '<none>',
-        'Create new',
+        'Create new ...',
         'Error_1',
         'Error_2',
         'Error_3'

--- a/test/spec/bpmn-properties-panel/provider/bpmn/MessageProps.bpmn
+++ b/test/spec/bpmn-properties-panel/provider/bpmn/MessageProps.bpmn
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0fsqrcy" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1">
+  <bpmn:process id="Process_03uklzr" isExecutable="true">
+    <bpmn:startEvent id="MessageEvent_1">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1x1jfqx" messageRef="Message_1" />
+    </bpmn:startEvent>
+    <bpmn:task id="Task_1" />
+    <bpmn:boundaryEvent id="MessageEvent_empty" attachedToRef="Task_1">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1lrhsfw" />
+    </bpmn:boundaryEvent>
+    <bpmn:startEvent id="StartEvent_1" />
+    <bpmn:receiveTask id="ReceiveTask_1" messageRef="Message_1" />
+    <bpmn:receiveTask id="ReceiveTask_empty" />
+  </bpmn:process>
+  <bpmn:message id="Message_1" name="Message_1" />
+  <bpmn:message id="Message_3" name="Message_3" />
+  <bpmn:message id="Message_2" name="Message_2" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_03uklzr">
+      <bpmndi:BPMNShape id="Event_03h9537_di" bpmnElement="MessageEvent_1">
+        <dc:Bounds x="179" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_08agven_di" bpmnElement="Task_1">
+        <dc:Bounds x="320" y="120" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0dc0qp6_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="222" y="252" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_11z9ewo_di" bpmnElement="ReceiveTask_1">
+        <dc:Bounds x="390" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_00gxxlu_di" bpmnElement="ReceiveTask_empty">
+        <dc:Bounds x="540" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0hk64mx_di" bpmnElement="MessageEvent_empty">
+        <dc:Bounds x="332" y="182" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/bpmn-properties-panel/provider/bpmn/MessageProps.spec.js
+++ b/test/spec/bpmn-properties-panel/provider/bpmn/MessageProps.spec.js
@@ -102,7 +102,7 @@ describe('provider/bpmn - MessageProps', function() {
       // then
       expect(asOptionNamesList(messageRefSelect)).to.eql([
         '<none>',
-        'Create new',
+        'Create new ...',
         'Message_1',
         'Message_2',
         'Message_3'
@@ -249,7 +249,7 @@ describe('provider/bpmn - MessageProps', function() {
       // then
       expect(asOptionNamesList(messageRefSelect)).to.eql([
         '<none>',
-        'Create new',
+        'Create new ...',
         'Message_1',
         'Message_2',
         'Message_3'

--- a/test/spec/bpmn-properties-panel/provider/bpmn/MessageProps.spec.js
+++ b/test/spec/bpmn-properties-panel/provider/bpmn/MessageProps.spec.js
@@ -1,0 +1,520 @@
+import TestContainer from 'mocha-test-container-support';
+import { act } from '@testing-library/preact';
+
+import {
+  bootstrapPropertiesPanel,
+  changeInput,
+  inject
+} from 'test/TestHelper';
+
+import {
+  query as domQuery,
+  queryAll as domQueryAll
+} from 'min-dom';
+
+import CoreModule from 'bpmn-js/lib/core';
+import SelectionModule from 'diagram-js/lib/features/selection';
+import ModelingModule from 'bpmn-js/lib/features/modeling';
+
+import BpmnPropertiesPanel from 'src/bpmn-properties-panel';
+
+import BpmnPropertiesProvider from 'src/bpmn-properties-panel/provider/bpmn';
+
+import {
+  getMessage
+} from 'src/bpmn-properties-panel/provider/bpmn/utils/EventDefinitionUtil';
+
+import diagramXML from './MessageProps.bpmn';
+
+
+describe('provider/bpmn - MessageProps', function() {
+
+  const testModules = [
+    CoreModule,
+    SelectionModule,
+    ModelingModule,
+    BpmnPropertiesPanel,
+    BpmnPropertiesProvider
+  ];
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  beforeEach(bootstrapPropertiesPanel(diagramXML, {
+    modules: testModules,
+    debounceInput: false
+  }));
+
+
+  describe('bpmn:StartEvent#messageRef', function() {
+
+    it('should NOT be displayed for normal start event',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('StartEvent_1');
+
+        // when
+        await act(() => {
+          selection.select(startEvent);
+        });
+
+        // then
+        const messageRefSelect = domQuery('select[name=messageRef]', container);
+
+        expect(messageRefSelect).to.be.null;
+      })
+    );
+
+
+    it('should display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const messageEvent = elementRegistry.get('MessageEvent_1');
+
+      await act(() => {
+        selection.select(messageEvent);
+      });
+
+      // when
+      const messageRefSelect = domQuery('select[name=messageRef]', container);
+
+      // then
+      expect(messageRefSelect.value).to.eql(getMessage(messageEvent).get('id'));
+    }));
+
+
+    it('should display select options in correct order', inject(async function(elementRegistry, selection) {
+
+      // given
+      const messageEvent = elementRegistry.get('MessageEvent_1');
+
+      await act(() => {
+        selection.select(messageEvent);
+      });
+
+      // when
+      const messageRefSelect = domQuery('select[name=messageRef]', container);
+
+      // then
+      expect(asOptionNamesList(messageRefSelect)).to.eql([
+        '<none>',
+        'Create new',
+        'Message_1',
+        'Message_2',
+        'Message_3'
+      ]);
+    }));
+
+
+    it('should update', inject(async function(elementRegistry, selection) {
+
+      // given
+      const messageEvent = elementRegistry.get('MessageEvent_1');
+
+      await act(() => {
+        selection.select(messageEvent);
+      });
+
+      // when
+      const messageRefSelect = domQuery('select[name=messageRef]', container);
+      changeInput(messageRefSelect, 'Message_2');
+
+      // then
+      expect(getMessage(messageEvent).get('id')).to.eql('Message_2');
+    }));
+
+
+    it('should create new message', inject(async function(elementRegistry, selection) {
+
+      // given
+      const messageEvent = elementRegistry.get('MessageEvent_empty');
+
+      await act(() => {
+        selection.select(messageEvent);
+      });
+
+      // assume
+      expect(getMessage(messageEvent)).to.not.exist;
+
+      // when
+      const messageRefSelect = domQuery('select[name=messageRef]', container);
+      changeInput(messageRefSelect, 'create-new');
+
+      // then
+      expect(getMessage(messageEvent)).to.exist;
+    }));
+
+
+    it('should remove message reference', inject(async function(elementRegistry, selection) {
+
+      // given
+      const messageEvent = elementRegistry.get('MessageEvent_1');
+
+      await act(() => {
+        selection.select(messageEvent);
+      });
+
+      // assume
+      expect(getMessage(messageEvent)).to.exist;
+
+      // when
+      const messageRefSelect = domQuery('select[name=messageRef]', container);
+      changeInput(messageRefSelect, '');
+
+      // then
+      expect(getMessage(messageEvent)).to.not.exist;
+    }));
+
+
+    it('should update on external change',
+      inject(async function(elementRegistry, selection, commandStack) {
+
+        // given
+        const messageEvent = elementRegistry.get('MessageEvent_1');
+        const originalValue = getMessage(messageEvent).get('id');
+
+        await act(() => {
+          selection.select(messageEvent);
+        });
+        const messageRefSelect = domQuery('select[name=messageRef]', container);
+        changeInput(messageRefSelect, 'Message_2');
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        // then
+        expect(messageRefSelect.value).to.eql(originalValue);
+      })
+    );
+
+  });
+
+
+  describe('bpmn:ReceiveTask#messageRef', function() {
+
+    it('should NOT be displayed for normal task',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        // when
+        await act(() => {
+          selection.select(task);
+        });
+
+        // then
+        const messageRefSelect = domQuery('select[name=messageRef]', container);
+
+        expect(messageRefSelect).to.be.null;
+      })
+    );
+
+
+    it('should display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const receiveTask = elementRegistry.get('ReceiveTask_1');
+
+      await act(() => {
+        selection.select(receiveTask);
+      });
+
+      // when
+      const messageRefSelect = domQuery('select[name=messageRef]', container);
+
+      // then
+      expect(messageRefSelect.value).to.eql(getMessage(receiveTask).get('id'));
+    }));
+
+
+    it('should display select options in correct order', inject(async function(elementRegistry, selection) {
+
+      // given
+      const receiveTask = elementRegistry.get('ReceiveTask_1');
+
+      await act(() => {
+        selection.select(receiveTask);
+      });
+
+      // when
+      const messageRefSelect = domQuery('select[name=messageRef]', container);
+
+      // then
+      expect(asOptionNamesList(messageRefSelect)).to.eql([
+        '<none>',
+        'Create new',
+        'Message_1',
+        'Message_2',
+        'Message_3'
+      ]);
+    }));
+
+
+    it('should update', inject(async function(elementRegistry, selection) {
+
+      // given
+      const receiveTask = elementRegistry.get('ReceiveTask_1');
+
+      await act(() => {
+        selection.select(receiveTask);
+      });
+
+      // when
+      const messageRefSelect = domQuery('select[name=messageRef]', container);
+      changeInput(messageRefSelect, 'Message_2');
+
+      // then
+      expect(getMessage(receiveTask).get('id')).to.eql('Message_2');
+    }));
+
+
+    it('should create new message', inject(async function(elementRegistry, selection) {
+
+      // given
+      const receiveTask = elementRegistry.get('ReceiveTask_empty');
+
+      await act(() => {
+        selection.select(receiveTask);
+      });
+
+      // assume
+      expect(getMessage(receiveTask)).to.not.exist;
+
+      // when
+      const messageRefSelect = domQuery('select[name=messageRef]', container);
+      changeInput(messageRefSelect, 'create-new');
+
+      // then
+      expect(getMessage(receiveTask)).to.exist;
+    }));
+
+
+    it('should remove message reference', inject(async function(elementRegistry, selection) {
+
+      // given
+      const receiveTask = elementRegistry.get('ReceiveTask_1');
+
+      await act(() => {
+        selection.select(receiveTask);
+      });
+
+      // assume
+      expect(getMessage(receiveTask)).to.exist;
+
+      // when
+      const messageRefSelect = domQuery('select[name=messageRef]', container);
+      changeInput(messageRefSelect, '');
+
+      // then
+      expect(getMessage(receiveTask)).to.not.exist;
+    }));
+
+
+    it('should update on external change',
+      inject(async function(elementRegistry, selection, commandStack) {
+
+        // given
+        const receiveTask = elementRegistry.get('ReceiveTask_1');
+        const originalValue = getMessage(receiveTask).get('id');
+
+        await act(() => {
+          selection.select(receiveTask);
+        });
+        const messageRefSelect = domQuery('select[name=messageRef]', container);
+        changeInput(messageRefSelect, 'Message_2');
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        // then
+        expect(messageRefSelect.value).to.eql(originalValue);
+      })
+    );
+
+  });
+
+
+  describe('bpmn:StartEvent#messageRef.name', function() {
+
+    it('should NOT be displayed for normal start event',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const startEvent = elementRegistry.get('StartEvent_1');
+
+        // when
+        await act(() => {
+          selection.select(startEvent);
+        });
+
+        // then
+        const messageNameInput = domQuery('input[name=messageName]', container);
+
+        expect(messageNameInput).to.be.null;
+      })
+    );
+
+
+    it('should display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const messageEvent = elementRegistry.get('MessageEvent_1');
+
+      await act(() => {
+        selection.select(messageEvent);
+      });
+
+      // when
+      const messageNameInput = domQuery('input[name=messageName]', container);
+
+      // then
+      expect(messageNameInput.value).to.eql(getMessage(messageEvent).get('name'));
+    }));
+
+
+    it('should update', inject(async function(elementRegistry, selection) {
+
+      // given
+      const messageEvent = elementRegistry.get('MessageEvent_1');
+
+      await act(() => {
+        selection.select(messageEvent);
+      });
+
+      // when
+      const messageNameInput = domQuery('input[name=messageName]', container);
+      changeInput(messageNameInput, 'newValue');
+
+      // then
+      expect(getMessage(messageEvent).get('name')).to.eql('newValue');
+    }));
+
+
+    it('should update on external change',
+      inject(async function(elementRegistry, selection, commandStack) {
+
+        // given
+        const messageEvent = elementRegistry.get('MessageEvent_1');
+        const originalValue = getMessage(messageEvent).get('name');
+
+        await act(() => {
+          selection.select(messageEvent);
+        });
+        const messageNameInput = domQuery('input[name=messageName]', container);
+        changeInput(messageNameInput, 'newValue');
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        // then
+        expect(messageNameInput.value).to.eql(originalValue);
+      })
+    );
+
+  });
+
+
+  describe('bpmn:ReceiveTask#messageRef.name', function() {
+
+    it('should NOT be displayed for normal task',
+      inject(async function(elementRegistry, selection) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        // when
+        await act(() => {
+          selection.select(task);
+        });
+
+        // then
+        const messageNameInput = domQuery('input[name=messageName]', container);
+
+        expect(messageNameInput).to.be.null;
+      })
+    );
+
+
+    it('should display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const receiveTask = elementRegistry.get('ReceiveTask_1');
+
+      await act(() => {
+        selection.select(receiveTask);
+      });
+
+      // when
+      const messageNameInput = domQuery('input[name=messageName]', container);
+
+      // then
+      expect(messageNameInput.value).to.eql(getMessage(receiveTask).get('name'));
+    }));
+
+
+    it('should update', inject(async function(elementRegistry, selection) {
+
+      // given
+      const receiveTask = elementRegistry.get('ReceiveTask_1');
+
+      await act(() => {
+        selection.select(receiveTask);
+      });
+
+      // when
+      const messageNameInput = domQuery('input[name=messageName]', container);
+      changeInput(messageNameInput, 'newValue');
+
+      // then
+      expect(getMessage(receiveTask).get('name')).to.eql('newValue');
+    }));
+
+
+    it('should update on external change',
+      inject(async function(elementRegistry, selection, commandStack) {
+
+        // given
+        const receiveTask = elementRegistry.get('ReceiveTask_1');
+        const originalValue = getMessage(receiveTask).get('name');
+
+        await act(() => {
+          selection.select(receiveTask);
+        });
+        const messageNameInput = domQuery('input[name=messageName]', container);
+        changeInput(messageNameInput, 'newValue');
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        // then
+        expect(messageNameInput.value).to.eql(originalValue);
+      })
+    );
+
+  });
+
+});
+
+// helper //////////////////////
+
+function asOptionNamesList(select) {
+  const names = [];
+  const options = domQueryAll('option', select);
+
+  options.forEach(o => names.push(o.label));
+
+  return names;
+}

--- a/test/spec/bpmn-properties-panel/provider/bpmn/ReferenceSelect.spec.js
+++ b/test/spec/bpmn-properties-panel/provider/bpmn/ReferenceSelect.spec.js
@@ -1,0 +1,135 @@
+import {
+  render
+} from '@testing-library/preact/pure';
+
+import TestContainer from 'mocha-test-container-support';
+
+import {
+  query as domQuery,
+  queryAll as domQueryAll
+} from 'min-dom';
+
+import {
+  insertCoreStyles,
+  changeInput
+} from 'test/TestHelper';
+
+import ReferenceSelect from 'src/bpmn-properties-panel/entries/ReferenceSelect';
+
+insertCoreStyles();
+
+const noop = () => {};
+
+
+describe('<ReferenceSelect>', function() {
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+
+  it('should render', function() {
+
+    // given
+    const result = createReferenceSelect({ container });
+
+    // then
+    expect(domQuery('.bio-properties-panel-select', result.container)).to.exist;
+  });
+
+
+  it('should render options', function() {
+
+    // given
+    const getOptions = () => [
+      {
+        label: 'option A',
+        value: 'A'
+      },
+      {
+        label: 'option B',
+        value: 'B'
+      },
+      {
+        label: 'option C',
+        value: 'C'
+      }
+    ];
+
+    // when
+    const result = createReferenceSelect({ container, getOptions });
+
+    const select = domQuery('.bio-properties-panel-select', result.container);
+
+    // then
+    expect(domQueryAll('option', select)).to.have.length(3);
+
+  });
+
+
+  it('should update', function() {
+
+    // given
+    const getOptions = () => [
+      {
+        label: 'option A',
+        value: 'A'
+      },
+      {
+        label: 'option B',
+        value: 'B'
+      },
+      {
+        label: 'option C',
+        value: 'C'
+      }
+    ];
+
+    const updateSpy = sinon.spy();
+
+    const result = createReferenceSelect({ container, setValue: updateSpy, getOptions });
+
+    const select = domQuery('.bio-properties-panel-input', result.container);
+
+    // when
+    changeInput(select, 'B');
+
+    // then
+    expect(updateSpy).to.have.been.calledWith('B');
+  });
+
+});
+
+
+// helpers ////////////////////
+
+function createReferenceSelect(options = {}) {
+  const {
+    autoFocuEntry,
+    element,
+    id = 'select',
+    description,
+    label,
+    getValue = noop,
+    setValue = noop,
+    getOptions = noop,
+    container
+  } = options;
+
+  return render(
+    <ReferenceSelect
+      autoFocuEntry={ autoFocuEntry }
+      element={ element }
+      id={ id }
+      label={ label }
+      description={ description }
+      getValue={ getValue }
+      setValue={ setValue }
+      getOptions={ getOptions } />,
+    {
+      container
+    }
+  );
+}


### PR DESCRIPTION
Closes #38 

This adds basic support for
* BPMN Errors
* BPMN Messages

Some notes to the reviewer:

* The zeebe specific message properties will be added on top in another PR (cf. #50). 
* The border below the two action options of the selects won't be implemented by now
* For now we have two `ElementUtil` which a bit of code duplication. Rationale: We don't know where the ZeebePropertiesProvider will live in the future. That's why I wanted to minimize the shared code for the providers.

![image](https://user-images.githubusercontent.com/9433996/120644906-26bd6c80-c478-11eb-84e7-fa72377401d2.png)

![image](https://user-images.githubusercontent.com/9433996/120645049-4c4a7600-c478-11eb-9b3c-81a50b8068ad.png)

![image](https://user-images.githubusercontent.com/9433996/120645541-d4308000-c478-11eb-9508-f4c1ae98f261.png)

