### PR TITLE
fix(zeebe-provider): avoid absolute paths in library code

### DIFF
--- a/src/bpmn-properties-panel/provider/zeebe/properties/OutputPropagationProps.js
+++ b/src/bpmn-properties-panel/provider/zeebe/properties/OutputPropagationProps.js
@@ -9,7 +9,7 @@ import {
 
 import {
   getCalledElement
-} from 'src/bpmn-properties-panel/provider/zeebe/utils/CalledElementUtil.js';
+} from '../utils/CalledElementUtil.js';
 
 import {
   has

--- a/src/bpmn-properties-panel/provider/zeebe/properties/TargetProps.js
+++ b/src/bpmn-properties-panel/provider/zeebe/properties/TargetProps.js
@@ -10,7 +10,7 @@ import {
 import {
   getCalledElement,
   getProcessId
-} from 'src/bpmn-properties-panel/provider/zeebe/utils/CalledElementUtil.js';
+} from '../utils/CalledElementUtil.js';
 
 import {
   useService


### PR DESCRIPTION
Using absolute paths inside the library will break rollup, e.g. when using it for our user testing prototype. 