### PR TITLE
fix(bpmn-properties-panel): do not select deleted elements

### DIFF
--- a/src/bpmn-properties-panel/BpmnPropertiesPanel.js
+++ b/src/bpmn-properties-panel/BpmnPropertiesPanel.js
@@ -32,9 +32,9 @@ export default function BpmnPropertiesPanel(props) {
     layoutConfig
   } = props;
 
-  const eventBus = injector.get('eventBus');
-
   const canvas = injector.get('canvas');
+  const elementRegistry = injector.get('elementRegistry');
+  const eventBus = injector.get('eventBus');
 
   const [ state, setState ] = useState({
     selectedElement: element
@@ -95,7 +95,7 @@ export default function BpmnPropertiesPanel(props) {
 
       const updatedElement = findElement(elements, selectedElement);
 
-      if (updatedElement) {
+      if (updatedElement && elementExists(updatedElement, elementRegistry)) {
         _update(updatedElement);
       }
     };
@@ -165,4 +165,8 @@ function isImplicitRoot(element) {
 
 function findElement(elements, element) {
   return find(elements, (e) => e === element);
+}
+
+function elementExists(element, elementRegistry) {
+  return element && elementRegistry.get(element.id);
 }

--- a/test/spec/bpmn-properties-panel/mocks/index.js
+++ b/test/spec/bpmn-properties-panel/mocks/index.js
@@ -2,6 +2,21 @@ class Canvas {
   getRootElement() {}
 }
 
+
+export class ElementRegistry {
+  constructor() {
+    this.elements = [];
+  }
+
+  setElements(elements) {
+    this.elements = elements;
+  }
+
+  get(id) {
+    return this.elements.find(e => e.id === id);
+  }
+}
+
 export class EventBus {
   constructor() {
     this.listeners = {};
@@ -35,6 +50,11 @@ export class Injector {
   }
 
   get(type) {
+
+    if (type === 'elementRegistry') {
+      return this._options.elementRegistry || new ElementRegistry();
+    }
+
     if (type === 'eventBus') {
       return this._options.eventBus || new EventBus();
     }


### PR DESCRIPTION
This prevents that we react to element updates for deleted elements. This is necessary because there might `element.changed` updates when an element got removed.

Closes #20
