### PR TITLE
style: remove bold title headers

### DIFF
--- a/assets/properties-panel.css
+++ b/assets/properties-panel.css
@@ -115,7 +115,6 @@
 
 .bio-properties-panel-group-header.empty .bio-properties-panel-group-header-title {
   opacity: 0.6;
-  font-weight: normal;
 }
 
 .bio-properties-panel-group-header {
@@ -132,7 +131,6 @@
 
 .bio-properties-panel-group-header .bio-properties-panel-group-header-title {
   opacity: 1;
-  font-weight: bold;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
Until we don't have proper data markers, we discussed making the "dirty / configured" - state less prominent.

**before**

![image](https://user-images.githubusercontent.com/9433996/121325522-f6f7e400-c911-11eb-89e8-2ae5eeb43e43.png)


**after**

![image](https://user-images.githubusercontent.com/9433996/121325348-d039ad80-c911-11eb-91fa-f811388d5484.png)

