### PR TITLE
Data Markers

### DIFF
--- a/assets/properties-panel.css
+++ b/assets/properties-panel.css
@@ -62,7 +62,6 @@
   margin-bottom: 2px;
   background-color: var(--color-background-light);
   border-bottom: 1px solid var(--color-cccccc);
-  border-top: 1px solid var(--color-aaaaaa);
   width: 100%;
   z-index: 1;
   max-height: 64px;
@@ -116,10 +115,6 @@
   border-bottom: 1px solid var(--color-cccccc);
 }
 
-.bio-properties-panel-group-header.empty .bio-properties-panel-group-header-title {
-  opacity: 0.6;
-}
-
 .bio-properties-panel-group-header {
   position: relative;
   display: flex;
@@ -127,13 +122,12 @@
   align-items: center;
   font-size: var(--text-size-base);
   height: 32px;
-  padding-right: 64px;
   user-select: none;
   overflow: hidden;
+  justify-content: space-between;
 }
 
 .bio-properties-panel-group-header .bio-properties-panel-group-header-title {
-  opacity: 1;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -141,17 +135,18 @@
 }
 
 .bio-properties-panel-group-header-buttons {
-  position: absolute;
-  right: 12px;
+  display: flex;
+  margin-right: 12px;
 }
 
 .bio-properties-panel-group-header-buttons .bio-properties-panel-group-header-button {
   display: inline-flex;
   justify-content: center;
   align-items: center;
+  align-self: center;
   width: 20px;
   height: 20px;
-  margin-right: 6px;
+  margin-right: 4px;
   padding: 0;
   border: none;
   background: none;
@@ -162,16 +157,11 @@
 }
 
 .bio-properties-panel-group-header-buttons .bio-properties-panel-add-entry {
-  opacity: 0.3;
   width: 20px;
   height: 20px;
   display: inherit;
   justify-content: center;
   align-items: center;
-}
-
-.bio-properties-panel-group-header-buttons .bio-properties-panel-add-entry:hover {
-  opacity: 1;
 }
 
 .bio-properties-panel-group-header:not(.empty) .bio-properties-panel-add-entry {
@@ -198,11 +188,12 @@
 
 .bio-properties-panel-arrow-down {
   transform: rotate(90deg);
-  opacity: 0.3;
 }
 
-.bio-properties-panel-arrow-right {
-  opacity: 0.3;
+.bio-properties-panel-dot {
+  width: 6px;
+  margin-right: 12px;
+  margin-top: -1px;
 }
 
 /**
@@ -223,15 +214,15 @@
 }
 
 .bio-properties-panel-list-badge {
-  align-self: center;
-  color: var(--color-000000-opacity-40);
-  border: 2px solid var(--color-000000-opacity-20);
+  color: var(--color-white);
+  background-color: var(--color-black);
+  border: 2px solid;
   border-radius: 20px;
-  min-width: 22px;
+  min-width: fit-content;
   font-size: 12px;
-  font-weight: 600;
   height: 22px;
   padding: 2px 6px;
+  margin-right: 4px;
   user-select: none;
   line-height: normal;
 }
@@ -239,10 +230,6 @@
 /**
  * Basic entries
  */
-.bio-properties-panel-add-entry {
-  opacity: 0.3;
-}
-
 .bio-properties-panel-entry {
   margin: 2px 12px 4px;
 }
@@ -458,14 +445,7 @@ textarea.bio-properties-panel-input {
   top: 0;
   width: 12px;
   height: 12px;
-}
-
-.bio-properties-panel-collapsible-entry-header .bio-properties-panel-arrow-down {
-  opacity: 1;
-}
-
-.bio-properties-panel-collapsible-entry-header .bio-properties-panel-arrow-right {
-  opacity: 1;
+  font-size: 16px;
 }
 
 .bio-properties-panel-remove-entry {
@@ -474,16 +454,11 @@ textarea.bio-properties-panel-input {
   right: 11px;
   width: 16px;
   height: 16px;
-  opacity: 0.3;
   visibility: hidden;
 }
 
 .bio-properties-panel-collapsible-entry-header:hover .bio-properties-panel-remove-entry {
   visibility: visible;
-}
-
-.bio-properties-panel-remove-entry:hover {
-  opacity: 1;
 }
 
 .bio-properties-panel-collapsible-entry-entries::before {

--- a/src/bpmn-properties-panel/provider/bpmn/BpmnPropertiesProvider.js
+++ b/src/bpmn-properties-panel/provider/bpmn/BpmnPropertiesProvider.js
@@ -1,6 +1,14 @@
 import Group from '../../../properties-panel/components/Group';
 
 import {
+  isEdited as textFieldIsEdited
+} from '../../../properties-panel/components/entries/TextField';
+
+import {
+  isEdited as checkboxIsEdited
+} from '../../../properties-panel/components/entries/Checkbox';
+
+import {
   DocumentationProps,
   ErrorProps,
   ExecutableProperty,
@@ -20,16 +28,19 @@ function GeneralGroup(element) {
   const entries = [
     {
       id: 'name',
-      component: <NameProperty element={ element } />
+      component: <NameProperty element={ element } />,
+      isEdited: textFieldIsEdited
     },
     {
       id: 'id',
-      component: <IdProperty element={ element } />
+      component: <IdProperty element={ element } />,
+      isEdited: textFieldIsEdited
     },
     ...ProcessProps({ element }),
     {
-      id: 'executable',
-      component: <ExecutableProperty element={ element } />
+      id: 'isExecutable',
+      component: <ExecutableProperty element={ element } />,
+      isEdited: checkboxIsEdited
     }
   ];
 

--- a/src/bpmn-properties-panel/provider/bpmn/properties/DocumentationProps.js
+++ b/src/bpmn-properties-panel/provider/bpmn/properties/DocumentationProps.js
@@ -3,7 +3,7 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import TextArea from '../../../../properties-panel/components/entries/TextArea';
+import TextArea, { isEdited as defaultIsEdited } from '../../../../properties-panel/components/entries/TextArea';
 
 import {
   useService
@@ -19,14 +19,16 @@ export function DocumentationProps(props) {
   const entries = [
     {
       id: 'documentation',
-      component: <ElementDocumentationProperty element={ element } />
+      component: <ElementDocumentationProperty element={ element } />,
+      isEdited: defaultIsEdited
     }
   ];
 
   if (hasProcessRef(element)) {
     entries.push({
       id: 'processDocumentation',
-      component: <ProcessDocumentationProperty element={ element } />
+      component: <ProcessDocumentationProperty element={ element } />,
+      isEdited: defaultIsEdited
     });
   }
 

--- a/src/bpmn-properties-panel/provider/bpmn/properties/ErrorProps.js
+++ b/src/bpmn-properties-panel/provider/bpmn/properties/ErrorProps.js
@@ -6,8 +6,9 @@ import {
   sortBy
 } from 'min-dash';
 
-import TextField from '../../../../properties-panel/components/entries/TextField';
+import TextField, { isEdited as textFieldIsEdited } from '../../../../properties-panel/components/entries/TextField';
 import ReferenceSelect from '../../../entries/ReferenceSelect';
+import { isEdited as selectIsEdited } from '../../../../properties-panel/components/entries/Select';
 
 import {
   useService
@@ -37,14 +38,26 @@ export function ErrorProps(props) {
   const error = getError(element);
 
   let entries = [
-    { id: 'errorRef', component: <ErrorRef element={ element } /> }
+    {
+      id: 'errorRef',
+      component: <ErrorRef element={ element } />,
+      isEdited: selectIsEdited
+    }
   ];
 
   if (error) {
     entries = [
       ...entries,
-      { id: 'errorName', component: <ErrorName element={ element } /> },
-      { id: 'errorCode', component: <ErrorCode element={ element } /> }
+      {
+        id: 'errorName',
+        component: <ErrorName element={ element } />,
+        isEdited: textFieldIsEdited
+      },
+      {
+        id: 'errorCode',
+        component: <ErrorCode element={ element } />,
+        isEdited: textFieldIsEdited
+      }
     ];
   }
 

--- a/src/bpmn-properties-panel/provider/bpmn/properties/MessageProps.js
+++ b/src/bpmn-properties-panel/provider/bpmn/properties/MessageProps.js
@@ -6,8 +6,9 @@ import {
   sortBy
 } from 'min-dash';
 
-import TextField from '../../../../properties-panel/components/entries/TextField';
+import TextField, { isEdited as textFieldIsEdited } from '../../../../properties-panel/components/entries/TextField';
 import ReferenceSelect from '../../../entries/ReferenceSelect';
+import { isEdited as selectIsEdited } from '../../../../properties-panel/components/entries/Select';
 
 import {
   useService
@@ -37,13 +38,21 @@ export function MessageProps(props) {
   const message = getMessage(element);
 
   let entries = [
-    { id: 'messageRef', component: <MessageRef element={ element } /> }
+    {
+      id: 'messageRef',
+      component: <MessageRef element={ element } />,
+      isEdited: selectIsEdited
+    }
   ];
 
   if (message) {
     entries = [
       ...entries,
-      { id: 'messageName', component: <MessageName element={ element } /> },
+      {
+        id: 'messageName',
+        component: <MessageName element={ element } />,
+        isEdited: textFieldIsEdited
+      },
     ];
   }
 

--- a/src/bpmn-properties-panel/provider/bpmn/properties/ProcessProps.js
+++ b/src/bpmn-properties-panel/provider/bpmn/properties/ProcessProps.js
@@ -1,5 +1,5 @@
 import { is } from 'bpmn-js/lib/util/ModelUtil';
-import TextField from '../../../../properties-panel/components/entries/TextField';
+import TextField, { isEdited as textFieldIsEdited } from '../../../../properties-panel/components/entries/TextField';
 
 import {
   useService
@@ -16,8 +16,16 @@ export function ProcessProps(props) {
   }
 
   return [
-    { id: 'processId', component: <ProcessId element={ element } /> },
-    { id: 'processName', component: <ProcessName element={ element } /> }
+    {
+      id: 'processId',
+      component: <ProcessId element={ element } />,
+      isEdited: textFieldIsEdited
+    },
+    {
+      id: 'processName',
+      component: <ProcessName element={ element } />,
+      isEdited: textFieldIsEdited
+    }
   ];
 }
 

--- a/src/bpmn-properties-panel/provider/zeebe/properties/ConditionProps.js
+++ b/src/bpmn-properties-panel/provider/zeebe/properties/ConditionProps.js
@@ -15,7 +15,7 @@ import {
   useService
 } from '../../../hooks';
 
-import TextField from '../../../../properties-panel/components/entries/TextField';
+import TextField, { isEdited as defaultIsEdited } from '../../../../properties-panel/components/entries/TextField';
 
 
 export function ConditionProps(props) {
@@ -30,7 +30,11 @@ export function ConditionProps(props) {
   const conditionProps = [];
 
   if (isConditionalSource(element.source)) {
-    conditionProps.push({ id: 'conditionExpression', component: <ConditionExpression element={ element } /> });
+    conditionProps.push({
+      id: 'conditionExpression',
+      component: <ConditionExpression element={ element } />,
+      isEdited: defaultIsEdited
+    });
   }
 
   return conditionProps;

--- a/src/bpmn-properties-panel/provider/zeebe/properties/FormProps.js
+++ b/src/bpmn-properties-panel/provider/zeebe/properties/FormProps.js
@@ -3,7 +3,7 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import TextField from '../../../../properties-panel/components/entries/TextField';
+import TextField, { isEdited as defaultIsEdited } from '../../../../properties-panel/components/entries/TextField';
 
 import {
   createElement
@@ -37,8 +37,9 @@ export function FormProps(props) {
 
   return [
     {
-      id: 'formDefinition',
-      component: <FormProperty element={ element } />
+      id: 'formConfiguration',
+      component: <FormProperty element={ element } />,
+      isEdited: defaultIsEdited
     }
   ];
 }

--- a/src/bpmn-properties-panel/provider/zeebe/properties/MessageProps.js
+++ b/src/bpmn-properties-panel/provider/zeebe/properties/MessageProps.js
@@ -6,7 +6,7 @@ import {
   isEventSubProcess
 } from 'bpmn-js/lib/util/DiUtil';
 
-import TextField from '../../../../properties-panel/components/entries/TextField';
+import TextField, { isEdited as defaultIsEdited } from '../../../../properties-panel/components/entries/TextField';
 
 import {
   useService
@@ -37,7 +37,11 @@ export function MessageProps(props) {
   }
 
   const entries = [
-    { id: 'messageSubscriptionCorrelationKey', component: <SubscriptionCorrelationKey element={ element } /> },
+    {
+      id: 'messageSubscriptionCorrelationKey',
+      component: <SubscriptionCorrelationKey element={ element } />,
+      isEdited: defaultIsEdited
+    },
   ];
 
   return entries;

--- a/src/bpmn-properties-panel/provider/zeebe/properties/MultiInstanceProps.js
+++ b/src/bpmn-properties-panel/provider/zeebe/properties/MultiInstanceProps.js
@@ -2,7 +2,7 @@ import {
   getBusinessObject
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import TextField from '../../../../properties-panel/components/entries/TextField';
+import TextField, { isEdited as defaultIsEdited } from '../../../../properties-panel/components/entries/TextField';
 
 import {
   getExtensionElementsList
@@ -27,10 +27,26 @@ export function MultiInstanceProps(props) {
   }
 
   return [
-    { id: 'multiInstance-inputCollection', component: <InputCollection element={ element } /> },
-    { id: 'multiInstance-inputElement', component: <InputElement element={ element } /> },
-    { id: 'multiInstance-outputCollection', component: <OutputCollection element={ element } /> },
-    { id: 'multiInstance-outputElement', component: <OutputElement element={ element } /> }
+    {
+      id: 'multiInstance-inputCollection',
+      component: <InputCollection element={ element } />,
+      isEdited: defaultIsEdited
+    },
+    {
+      id: 'multiInstance-inputElement',
+      component: <InputElement element={ element } />,
+      isEdited: defaultIsEdited
+    },
+    {
+      id: 'multiInstance-outputCollection',
+      component: <OutputCollection element={ element } />,
+      isEdited: defaultIsEdited
+    },
+    {
+      id: 'multiInstance-outputElement',
+      component: <OutputElement element={ element } />,
+      isEdited: defaultIsEdited
+    }
   ];
 }
 

--- a/src/bpmn-properties-panel/provider/zeebe/properties/OutputPropagationProps.js
+++ b/src/bpmn-properties-panel/provider/zeebe/properties/OutputPropagationProps.js
@@ -23,7 +23,7 @@ import {
   useService
 } from '../../../hooks';
 
-import ToggleSwitch from '../../../../properties-panel/components/entries/ToggleSwitch';
+import ToggleSwitch, { isEdited as defaultIsEdited } from '../../../../properties-panel/components/entries/ToggleSwitch';
 
 
 export function OutputPropagationProps(props) {
@@ -36,7 +36,12 @@ export function OutputPropagationProps(props) {
   }
 
   return [
-    { id: 'propagateAllChildVariables', component: <PropagateAllChildVariables element={ element } /> } ];
+    {
+      id: 'propagateAllChildVariables',
+      component: <PropagateAllChildVariables element={ element } />,
+      isEdited: defaultIsEdited
+    }
+  ];
 }
 
 function PropagateAllChildVariables(props) {

--- a/src/bpmn-properties-panel/provider/zeebe/properties/TargetProps.js
+++ b/src/bpmn-properties-panel/provider/zeebe/properties/TargetProps.js
@@ -16,7 +16,7 @@ import {
   useService
 } from '../../../hooks';
 
-import TextField from '../../../../properties-panel/components/entries/TextField';
+import TextField, { isEdited as defaultIsEdited } from '../../../../properties-panel/components/entries/TextField';
 
 
 export function TargetProps(props) {
@@ -28,7 +28,13 @@ export function TargetProps(props) {
     return [];
   }
 
-  return [ { id: 'targetProcessId', component: <TargetProcessId element={ element } /> } ];
+  return [
+    {
+      id: 'targetProcessId',
+      component: <TargetProcessId element={ element } />,
+      isEdited: defaultIsEdited
+    }
+  ];
 }
 
 function TargetProcessId(props) {

--- a/src/bpmn-properties-panel/provider/zeebe/properties/TaskDefinitionProps.js
+++ b/src/bpmn-properties-panel/provider/zeebe/properties/TaskDefinitionProps.js
@@ -3,7 +3,7 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import TextField from '../../../../properties-panel/components/entries/TextField';
+import TextField, { isEdited as textFieldIsEdited } from '../../../../properties-panel/components/entries/TextField';
 
 import {
   getExtensionElementsList
@@ -28,8 +28,16 @@ export function TaskDefinitionProps(props) {
   }
 
   return [
-    { id: 'taskDefinitionType', component: <TaskDefinitionType element={ element } /> },
-    { id: 'taskDefinitionRetries', component: <TaskDefinitionRetries element={ element } /> }
+    {
+      id: 'taskDefinitionType',
+      component: <TaskDefinitionType element={ element } />,
+      isEdited: textFieldIsEdited
+    },
+    {
+      id: 'taskDefinitionRetries',
+      component: <TaskDefinitionRetries element={ element } />,
+      isEdited: textFieldIsEdited
+    }
   ];
 }
 

--- a/src/properties-panel/PropertiesPanel.js
+++ b/src/properties-panel/PropertiesPanel.js
@@ -28,7 +28,8 @@ function renderGroup(props) {
 /**
  * @typedef { {
  *    component: import('preact').ComponentChild,
- *    id: String
+ *    id: String,
+ *    isEdited?: Function
  * } } EntryDefinition
  *
  * @typedef { {

--- a/src/properties-panel/components/Group.js
+++ b/src/properties-panel/components/Group.js
@@ -1,8 +1,17 @@
 import {
+  useEffect,
   useState
 } from 'preact/hooks';
 
 import classnames from 'classnames';
+
+import {
+  query as domQuery
+} from 'min-dom';
+
+import {
+  isFunction
+} from 'min-dash';
 
 import { GroupArrowIcon } from './icons';
 
@@ -20,12 +29,42 @@ export default function Group(props) {
 
   const toggleOpen = () => setOpen(!open);
 
+  const [ edited, setEdited ] = useState(false);
+
+  // set edited state depending on all entries
+  useEffect(() => {
+    const hasOneEditedEntry = entries.find(entry => {
+      const {
+        id,
+        isEdited
+      } = entry;
+
+      const entryNode = domQuery(`[data-entry-id="${id}"]`);
+
+      if (!isFunction(isEdited) || !entryNode) {
+        return false;
+      }
+
+      const inputNode = domQuery('.bio-properties-panel-input', entryNode);
+
+      return isEdited(inputNode);
+    });
+
+    setEdited(hasOneEditedEntry);
+  }, [ entries ]);
+
   return <div class="bio-properties-panel-group" data-group-id={ 'group-' + id }>
-    <div class="bio-properties-panel-group-header" onClick={ toggleOpen }>
-      <div title={ label } class="bio-properties-panel-group-header-title">
+    <div class={ classnames(
+      'bio-properties-panel-group-header',
+      edited ? '' : 'empty'
+    ) } onClick={ toggleOpen }>
+      <div title={ getTitleAttribute(label, edited) } class="bio-properties-panel-group-header-title">
         { label }
       </div>
       <div class="bio-properties-panel-group-header-buttons">
+        {
+          edited && <DataMarker />
+        }
         <div class="bio-properties-panel-group-header-button">
           <GroupArrowIcon class={ open ? 'bio-properties-panel-arrow-down' : 'bio-properties-panel-arrow-right' } />
         </div>
@@ -40,4 +79,24 @@ export default function Group(props) {
       }
     </div>
   </div>;
+}
+
+function DataMarker() {
+  return (
+    <div class="bio-properties-panel-dot">
+      <svg
+        aria-label="edited" role="img" xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 100 100"
+      >
+        <circle fill="currentColor" cx="50" cy="50" r="50" />
+      </svg>
+    </div>
+  );
+}
+
+
+// helper //////////////
+
+function getTitleAttribute(label, edited) {
+  return label + (edited ? ' (edited)' : '');
 }

--- a/src/properties-panel/components/ListGroup.js
+++ b/src/properties-panel/components/ListGroup.js
@@ -119,7 +119,7 @@ export default function ListGroup(props) {
         hasItems ? '' : 'empty'
       ) }
       onClick={ hasItems ? toggleOpen : noop }>
-      <div title={ label } class="bio-properties-panel-group-header-title">
+      <div title={ getTitleAttribute(label, items) } class="bio-properties-panel-group-header-title">
         { label }
       </div>
       <div class="bio-properties-panel-group-header-buttons">
@@ -192,4 +192,10 @@ function createOrdering(items) {
 
 function removeDuplicates(items) {
   return items.filter((i, index) => items.indexOf(i) === index);
+}
+
+function getTitleAttribute(label, items) {
+  const count = items.length;
+
+  return label + (count ? ` (${count} item${count != 1 ? 's' : ''})` : '');
 }

--- a/src/properties-panel/components/ListGroup.js
+++ b/src/properties-panel/components/ListGroup.js
@@ -122,21 +122,21 @@ export default function ListGroup(props) {
       <div title={ label } class="bio-properties-panel-group-header-title">
         { label }
       </div>
-      {
-        hasItems
-          ? (
-            <div class="bio-properties-panel-list-badge">
-              { items.length }
-            </div>
-          )
-          : null
-      }
       <div class="bio-properties-panel-group-header-buttons">
         <AddContainer>
           <div class="bio-properties-panel-add-entry">
             <CreateIcon />
           </div>
         </AddContainer>
+        {
+          hasItems
+            ? (
+              <div class="bio-properties-panel-list-badge">
+                { items.length }
+              </div>
+            )
+            : null
+        }
         {
           hasItems
             ? (

--- a/src/properties-panel/components/entries/Checkbox.js
+++ b/src/properties-panel/components/entries/Checkbox.js
@@ -51,6 +51,10 @@ export default function CheckboxEntry(props) {
   );
 }
 
+export function isEdited(node) {
+  return node && !!node.checked;
+}
+
 
 // helpers /////////////////
 

--- a/src/properties-panel/components/entries/Select.js
+++ b/src/properties-panel/components/entries/Select.js
@@ -82,6 +82,9 @@ export default function SelectEntry(props) {
   );
 }
 
+export function isEdited(node) {
+  return node && !!node.value;
+}
 
 // helpers /////////////////
 

--- a/src/properties-panel/components/entries/TextArea.js
+++ b/src/properties-panel/components/entries/TextArea.js
@@ -72,6 +72,10 @@ export default function TextAreaEntry(props) {
   );
 }
 
+export function isEdited(node) {
+  return node && !!node.value;
+}
+
 
 // helpers /////////////////
 

--- a/src/properties-panel/components/entries/TextField.js
+++ b/src/properties-panel/components/entries/TextField.js
@@ -64,6 +64,10 @@ export default function TextfieldEntry(props) {
   );
 }
 
+export function isEdited(node) {
+  return node && !!node.value;
+}
+
 
 // helpers /////////////////
 

--- a/src/properties-panel/components/entries/ToggleSwitch.js
+++ b/src/properties-panel/components/entries/ToggleSwitch.js
@@ -62,6 +62,10 @@ export default function ToggleSwitchEntry(props) {
   );
 }
 
+export function isEdited(node) {
+  return node && !!node.checked;
+}
+
 
 // helpers /////////////////
 

--- a/test/spec/properties-panel/components/Checkbox.spec.js
+++ b/test/spec/properties-panel/components/Checkbox.spec.js
@@ -13,7 +13,7 @@ import {
   clickInput
 } from 'test/TestHelper';
 
-import Checkbox from 'src/properties-panel/components/entries/Checkbox';
+import Checkbox, { isEdited } from 'src/properties-panel/components/entries/Checkbox';
 
 insertCoreStyles();
 
@@ -53,6 +53,58 @@ describe('<Checkbox>', function() {
 
     // then
     expect(updateSpy).to.have.been.calledWith(true);
+  });
+
+
+  describe('#isEdited', function() {
+
+    it('should NOT be edited', function() {
+
+      // given
+      const result = createCheckbox({ container });
+
+      const input = domQuery('.bio-properties-panel-input', result.container);
+
+      // when
+      const edited = isEdited(input);
+
+      // then
+      expect(edited).to.be.false;
+    });
+
+
+    it('should be edited', function() {
+
+      // given
+      const result = createCheckbox({ container, getValue: () => 'foo' });
+
+      const input = domQuery('.bio-properties-panel-input', result.container);
+
+      // when
+      const edited = isEdited(input);
+
+      // then
+      expect(edited).to.be.true;
+    });
+
+
+    it('should be edited after update', function() {
+
+      // given
+      const result = createCheckbox({ container });
+
+      const input = domQuery('.bio-properties-panel-input', result.container);
+
+      // assume
+      expect(isEdited(input)).to.be.false;
+
+      // when
+      clickInput(input);
+
+      // then
+      expect(isEdited(input)).to.be.true;
+    });
+
   });
 
 });

--- a/test/spec/properties-panel/components/Group.spec.js
+++ b/test/spec/properties-panel/components/Group.spec.js
@@ -5,6 +5,7 @@ import {
 import TestContainer from 'mocha-test-container-support';
 
 import {
+  attr as domAttr,
   classes as domClasses,
   query as domQuery
 } from 'min-dom';
@@ -135,6 +136,43 @@ describe('<Group>', function() {
 
       // then
       expect(dataMarker).to.exist;
+    });
+
+  });
+
+
+  describe('title attributes', function() {
+
+    it('should have title for empty groups', function() {
+
+      // given
+      const result = createGroup({ container, label: 'Group' });
+
+      const header = domQuery('.bio-properties-panel-group-header', result.container);
+
+      const title = domQuery('.bio-properties-panel-group-header-title', header);
+
+      // then
+      expect(domAttr(title, 'title')).to.eql('Group');
+    });
+
+
+    it('should have title for configured groups', function() {
+
+      // given
+      const entries = createEntries({
+        isEdited: () => true,
+        entryComponent: <TestEntry id="entry1" value="foo" />,
+      });
+
+      const result = createGroup({ container, label: 'Group', entries });
+
+      const header = domQuery('.bio-properties-panel-group-header', result.container);
+
+      const title = domQuery('.bio-properties-panel-group-header-title', header);
+
+      // then
+      expect(domAttr(title, 'title')).to.eql('Group (edited)');
     });
 
   });

--- a/test/spec/properties-panel/components/Group.spec.js
+++ b/test/spec/properties-panel/components/Group.spec.js
@@ -5,8 +5,8 @@ import {
 import TestContainer from 'mocha-test-container-support';
 
 import {
-  query as domQuery,
-  classes as domClasses
+  classes as domClasses,
+  query as domQuery
 } from 'min-dom';
 
 import {
@@ -16,6 +16,8 @@ import {
 import Group from 'src/properties-panel/components/Group';
 
 insertCoreStyles();
+
+const noop = () => {};
 
 
 describe('<Group>', function() {
@@ -56,6 +58,87 @@ describe('<Group>', function() {
     expect(domClasses(entries).has('open')).to.be.true;
   });
 
+
+  describe('data markers', function() {
+
+    it('should NOT show group as edited - empty entries', function() {
+
+      // given
+      const entries = createEntries();
+
+      // when
+      const result = createGroup({ container, label: 'Group', entries });
+
+      const header = domQuery('.bio-properties-panel-group-header', result.container);
+
+      const dataMarker = domQuery('.bio-properties-panel-dot', header);
+
+      // then
+      expect(dataMarker).not.to.exist;
+    });
+
+
+    it('should NOT show group as edited - empty entry input', function() {
+
+      // given
+      const entries = createEntries({
+        isEdited: (node) => !!node.value,
+        entryComponent: <TestEntry id="entry1" />,
+      });
+
+      // when
+      const result = createGroup({ container, label: 'Group', entries });
+
+      const header = domQuery('.bio-properties-panel-group-header', result.container);
+
+      const dataMarker = domQuery('.bio-properties-panel-dot', header);
+
+      // then
+      expect(dataMarker).not.to.exist;
+    });
+
+
+    it('should NOT show group as edited - always false', function() {
+
+      // given
+      const entries = createEntries({
+        isEdited: () => false,
+        entryComponent: <TestEntry id="entry1" value="foo" />,
+      });
+
+      // when
+      const result = createGroup({ container, label: 'Group', entries });
+
+      const header = domQuery('.bio-properties-panel-group-header', result.container);
+
+      const dataMarker = domQuery('.bio-properties-panel-dot', header);
+
+      // then
+      expect(dataMarker).not.to.exist;
+    });
+
+
+    it('should show group as edited', function() {
+
+      // given
+      const entries = createEntries({
+        isEdited: (node) => !!node.value,
+        entryComponent: <TestEntry id="entry1" value="foo" />,
+      });
+
+      // when
+      const result = createGroup({ container, label: 'Group', entries });
+
+      const header = domQuery('.bio-properties-panel-group-header', result.container);
+
+      const dataMarker = domQuery('.bio-properties-panel-dot', header);
+
+      // then
+      expect(dataMarker).to.exist;
+    });
+
+  });
+
 });
 
 
@@ -75,4 +158,40 @@ function createGroup(options = {}) {
       container
     }
   );
+}
+
+function createEntries(overrides = {}) {
+  const {
+    entries = [],
+    isEdited = noop,
+    entryComponent
+  } = overrides;
+
+  const newEntries = [
+    {
+      id: 'entry1',
+      component: entryComponent,
+      isEdited
+    },
+    {
+      id: 'entry2'
+    },
+    {
+      id: 'entry2'
+    },
+    ...entries
+  ];
+
+  return newEntries;
+}
+
+function TestEntry(props) {
+  const {
+    id,
+    value
+  } = props;
+
+  return <div data-entry-id={ id }>
+    <input className="bio-properties-panel-input" value={ value }></input>
+  </div>;
 }

--- a/test/spec/properties-panel/components/ListGroup.spec.js
+++ b/test/spec/properties-panel/components/ListGroup.spec.js
@@ -514,6 +514,49 @@ describe('<ListGroup>', function() {
     ]);
   });
 
+
+  describe('title attributes', function() {
+
+    it('should have title for empty lists', function() {
+
+      // given
+      const { container } = createListGroup({ container: parentContainer });
+
+      const header = domQuery('.bio-properties-panel-group-header', container);
+
+      const title = domQuery('.bio-properties-panel-group-header-title', header);
+
+      // then
+      expect(domAttr(title, 'title')).to.eql('List');
+    });
+
+
+    it('should have title for list with items', function() {
+
+      // given
+      const items = [
+        {
+          id: 'foo',
+          label: 'Item 1'
+        },
+        {
+          id: 'bar',
+          label: 'Item 2'
+        }
+      ];
+
+      const { container } = createListGroup({ container: parentContainer, items });
+
+      const header = domQuery('.bio-properties-panel-group-header', container);
+
+      const title = domQuery('.bio-properties-panel-group-header-title', header);
+
+      // then
+      expect(domAttr(title, 'title')).to.eql('List (2 items)');
+    });
+
+  });
+
 });
 
 

--- a/test/spec/properties-panel/components/Select.spec.js
+++ b/test/spec/properties-panel/components/Select.spec.js
@@ -14,7 +14,7 @@ import {
   changeInput
 } from 'test/TestHelper';
 
-import Select from 'src/properties-panel/components/entries/Select';
+import Select, { isEdited } from 'src/properties-panel/components/entries/Select';
 
 insertCoreStyles();
 
@@ -43,20 +43,7 @@ describe('<Select>', function() {
   it('should render options', function() {
 
     // given
-    const getOptions = () => [
-      {
-        label: 'option A',
-        value: 'A'
-      },
-      {
-        label: 'option B',
-        value: 'B'
-      },
-      {
-        label: 'option C',
-        value: 'C'
-      }
-    ];
+    const getOptions = () => createOptions();
 
     // when
     const result = createSelect({ container, getOptions });
@@ -64,7 +51,7 @@ describe('<Select>', function() {
     const select = domQuery('.bio-properties-panel-select', result.container);
 
     // then
-    expect(domQueryAll('option', select)).to.have.length(3);
+    expect(domQueryAll('option', select)).to.have.length(4);
 
   });
 
@@ -72,20 +59,7 @@ describe('<Select>', function() {
   it('should update', function() {
 
     // given
-    const getOptions = () => [
-      {
-        label: 'option A',
-        value: 'A'
-      },
-      {
-        label: 'option B',
-        value: 'B'
-      },
-      {
-        label: 'option C',
-        value: 'C'
-      }
-    ];
+    const getOptions = () => createOptions();
 
     const updateSpy = sinon.spy();
 
@@ -98,6 +72,64 @@ describe('<Select>', function() {
 
     // then
     expect(updateSpy).to.have.been.calledWith('B');
+  });
+
+
+  describe('#isEdited', function() {
+
+    it('should NOT be edited', function() {
+
+      // given
+      const getOptions = () => createOptions();
+
+      const result = createSelect({ container, getOptions });
+
+      const select = domQuery('.bio-properties-panel-input', result.container);
+
+      // when
+      const edited = isEdited(select);
+
+      // then
+      expect(edited).to.be.false;
+    });
+
+
+    it('should be edited', function() {
+
+      // given
+      const getOptions = () => createOptions();
+
+      const result = createSelect({ container, getOptions, getValue: () => 'B' });
+
+      const select = domQuery('.bio-properties-panel-input', result.container);
+
+      // when
+      const edited = isEdited(select);
+
+      // then
+      expect(edited).to.be.true;
+    });
+
+
+    it('should be edited after update', function() {
+
+      // given
+      const getOptions = () => createOptions();
+
+      const result = createSelect({ container, getOptions });
+
+      const select = domQuery('.bio-properties-panel-input', result.container);
+
+      // assume
+      expect(isEdited(select)).to.be.false;
+
+      // when
+      changeInput(select, 'B');
+
+      // then
+      expect(isEdited(select)).to.be.true;
+    });
+
   });
 
 });
@@ -130,4 +162,31 @@ function createSelect(options = {}) {
       container
     }
   );
+}
+
+function createOptions(overrides = {}) {
+  const {
+    options = []
+  } = overrides;
+
+  const newOptions = [
+    {
+      value: ''
+    },
+    {
+      label: 'option A',
+      value: 'A'
+    },
+    {
+      label: 'option B',
+      value: 'B'
+    },
+    {
+      label: 'option C',
+      value: 'C'
+    },
+    ...options
+  ];
+
+  return newOptions;
 }

--- a/test/spec/properties-panel/components/TextArea.spec.js
+++ b/test/spec/properties-panel/components/TextArea.spec.js
@@ -13,7 +13,7 @@ import {
   changeInput
 } from 'test/TestHelper';
 
-import TextArea from 'src/properties-panel/components/entries/TextArea';
+import TextArea, { isEdited } from 'src/properties-panel/components/entries/TextArea';
 
 insertCoreStyles();
 
@@ -53,6 +53,58 @@ describe('<TextArea>', function() {
 
     // then
     expect(updateSpy).to.have.been.calledWith('foo');
+  });
+
+
+  describe('#isEdited', function() {
+
+    it('should NOT be edited', function() {
+
+      // given
+      const result = createTextArea({ container });
+
+      const input = domQuery('.bio-properties-panel-input', result.container);
+
+      // when
+      const edited = isEdited(input);
+
+      // then
+      expect(edited).to.be.false;
+    });
+
+
+    it('should be edited', function() {
+
+      // given
+      const result = createTextArea({ container, getValue: () => 'foo' });
+
+      const input = domQuery('.bio-properties-panel-input', result.container);
+
+      // when
+      const edited = isEdited(input);
+
+      // then
+      expect(edited).to.be.true;
+    });
+
+
+    it('should be edited after update', function() {
+
+      // given
+      const result = createTextArea({ container });
+
+      const input = domQuery('.bio-properties-panel-input', result.container);
+
+      // assume
+      expect(isEdited(input)).to.be.false;
+
+      // when
+      changeInput(input, 'foo');
+
+      // then
+      expect(isEdited(input)).to.be.true;
+    });
+
   });
 
 });

--- a/test/spec/properties-panel/components/TextField.spec.js
+++ b/test/spec/properties-panel/components/TextField.spec.js
@@ -13,7 +13,7 @@ import {
   changeInput
 } from 'test/TestHelper';
 
-import TextField from 'src/properties-panel/components/entries/TextField';
+import TextField, { isEdited } from 'src/properties-panel/components/entries/TextField';
 
 insertCoreStyles();
 
@@ -53,6 +53,58 @@ describe('<TextField>', function() {
 
     // then
     expect(updateSpy).to.have.been.calledWith('foo');
+  });
+
+
+  describe('#isEdited', function() {
+
+    it('should NOT be edited', function() {
+
+      // given
+      const result = createTextField({ container });
+
+      const input = domQuery('.bio-properties-panel-input', result.container);
+
+      // when
+      const edited = isEdited(input);
+
+      // then
+      expect(edited).to.be.false;
+    });
+
+
+    it('should be edited', function() {
+
+      // given
+      const result = createTextField({ container, getValue: () => 'foo' });
+
+      const input = domQuery('.bio-properties-panel-input', result.container);
+
+      // when
+      const edited = isEdited(input);
+
+      // then
+      expect(edited).to.be.true;
+    });
+
+
+    it('should be edited after update', function() {
+
+      // given
+      const result = createTextField({ container });
+
+      const input = domQuery('.bio-properties-panel-input', result.container);
+
+      // assume
+      expect(isEdited(input)).to.be.false;
+
+      // when
+      changeInput(input, 'foo');
+
+      // then
+      expect(isEdited(input)).to.be.true;
+    });
+
   });
 
 });

--- a/test/spec/properties-panel/components/ToggleSwitch.spec.js
+++ b/test/spec/properties-panel/components/ToggleSwitch.spec.js
@@ -13,7 +13,7 @@ import {
   clickInput
 } from 'test/TestHelper';
 
-import ToggleSwitch from 'src/properties-panel/components/entries/ToggleSwitch';
+import ToggleSwitch, { isEdited } from 'src/properties-panel/components/entries/ToggleSwitch';
 
 insertCoreStyles();
 
@@ -114,6 +114,59 @@ describe('<TextField>', function() {
     expect(label.innerHTML).to.equal('myLabel');
     expect(switchLabel.innerHTML).to.equal('mySwitcherLabel');
     expect(description.innerHTML).to.equal('myDescription');
+  });
+
+
+
+  describe('#isEdited', function() {
+
+    it('should NOT be edited', function() {
+
+      // given
+      const result = createToggleSwitch({ container });
+
+      const input = domQuery('.bio-properties-panel-input', result.container);
+
+      // when
+      const edited = isEdited(input);
+
+      // then
+      expect(edited).to.be.false;
+    });
+
+
+    it('should be edited', function() {
+
+      // given
+      const result = createToggleSwitch({ container, getValue: () => 'foo' });
+
+      const input = domQuery('.bio-properties-panel-input', result.container);
+
+      // when
+      const edited = isEdited(input);
+
+      // then
+      expect(edited).to.be.true;
+    });
+
+
+    it('should be edited after update', function() {
+
+      // given
+      const result = createToggleSwitch({ container });
+
+      const input = domQuery('.bio-properties-panel-input', result.container);
+
+      // assume
+      expect(isEdited(input)).to.be.false;
+
+      // when
+      clickInput(input);
+
+      // then
+      expect(isEdited(input)).to.be.true;
+    });
+
   });
 
 });


### PR DESCRIPTION
Closes #23 

* moves list count markers to the right
* introduces data markers for normal groups - general approach: a group is `edited` when at least one entry is `edited`
* improves title attributes with data markers for header titles as a quick fix ==> Note: we will handle the whole `title` story on the general design polishing!

![image](https://user-images.githubusercontent.com/9433996/123393097-0f1c6400-d59e-11eb-9352-9bd712bed81e.png)

