### PR TITLE
ID Validation

### DIFF
--- a/assets/properties-panel.css
+++ b/assets/properties-panel.css
@@ -2,9 +2,13 @@
  * Theming
  */
 .bio-properties-panel {
-  --silver-darken-80: #cdcdcd;
+  --color-silver-darken-80: #cdcdcd;
 
-  --blue-base-65: #4d90ff;
+  --color-blue-205-100-95: #e5f4ff;
+  --color-blue-205-100-50: #0095ff;
+
+  --color-red-360-100-97: #fff0f0;
+  --color-red-360-100-45: #e60000;
 
   --color-cccccc: #cccccc;
   --color-aaaaaa: #aaaaaa;
@@ -16,11 +20,21 @@
   --color-000000-opacity-40: rgba(0, 0, 0, 0.4);
 
   --color-background-light: #e8eaee;
-  --color-line-base: #d2d2d2;
 
-  --color-input-background: #f3f4f6;
-  --color-input-focus: #0391ef;
-  --color-input-focus-light: #f4faff;
+  --color-input-background: #f1f2f4;
+  --color-input-border: #d5d6dd;
+  --color-input-background-focus: var(--color-blue-205-100-95);
+  --color-input-border-focus: var(--color-blue-205-100-50);
+
+  --color-input-background-error: var(--color-red-360-100-97);
+  --color-input-border-error: var(--color-red-360-100-45);
+  --color-input-border-error-focus: var(--color-blue-205-100-50);
+
+  --color-toggle-switch-background-on: var(--color-blue-205-100-50);
+  --color-toggle-switch-background-off: var(--color-silver-darken-80);
+
+  --color-text-base: var(--color-black);
+  --color-text-error: var(--color-red-360-100-45);
 
   --text-size-base: 14px;
   --text-line-height: 1.5;
@@ -242,7 +256,6 @@
 .bio-properties-panel-description {
   display: block;
   margin: 4px 0;
-  font-size: 14px;
   line-height: 18px;
   font-weight: 400;
   font-size: 13px;
@@ -254,7 +267,7 @@
 
 .bio-properties-panel-input {
   padding: 5px 6px 4px;
-  border: 1px solid var(--color-line-base);
+  border: 1px solid var(--color-input-border);
   border-radius: 3px;
   background-color: var(--color-input-background);
   font-size: 14px;
@@ -270,8 +283,8 @@ textarea.bio-properties-panel-input,
 
 .bio-properties-panel-input:focus {
   outline: none;
-  background-color: var(--color-input-focus-light);
-  border: 1px solid var(--color-input-focus);
+  background-color: var(--color-input-background-focus);
+  border: 1px solid var(--color-input-border-focus);
 }
 
 .bio-properties-panel-input[type="checkbox"], .bio-properties-panel-input[type="radio"] {
@@ -323,7 +336,7 @@ textarea.bio-properties-panel-input,
 
 .bio-properties-panel-checkbox .bio-properties-panel-label::before {
   content: " ";
-  border: 1px solid var(--color-line-base);
+  border: 1px solid var(--color-input-border);
   border-radius: 3px;
   background-color:var(--color-000000-opacity-5);
 }
@@ -337,6 +350,21 @@ textarea.bio-properties-panel-input,
 
 textarea.bio-properties-panel-input {
   resize: vertical;
+}
+
+.bio-properties-panel-entry.has-error .bio-properties-panel-input {
+  border-color: var(--color-input-border-error);
+  background-color: var(--color-input-background-error);
+}
+
+.bio-properties-panel-entry.has-error .bio-properties-panel-input:focus {
+  border-color: var(--color-input-border-error-focus);
+}
+
+.bio-properties-panel-entry .bio-properties-panel-error {
+  color: var(--color-text-error);
+  margin: 4px 0;
+  font-size: 13px;
 }
 
 /**
@@ -372,7 +400,7 @@ textarea.bio-properties-panel-input {
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: var(--silver-darken-80);
+  background-color: var(--color-toggle-switch-background-off);
   -webkit-transition: 0.4s;
   transition: 0.4s;
   border-radius: 34px;
@@ -392,7 +420,7 @@ textarea.bio-properties-panel-input {
 }
 
 .bio-properties-panel-toggle-switch .bio-properties-panel-toggle-switch__switcher input[type='checkbox']:checked + .bio-properties-panel-toggle-switch__slider {
-  background-color: var(--blue-base-65);
+  background-color: var(--color-toggle-switch-background-on);
   box-shadow: 0 0 1px ;
 }
 

--- a/src/bpmn-properties-panel/provider/bpmn/properties/Id.js
+++ b/src/bpmn-properties-panel/provider/bpmn/properties/Id.js
@@ -1,4 +1,5 @@
 import {
+  getBusinessObject,
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
@@ -7,6 +8,10 @@ import TextField from '../../../../properties-panel/components/entries/TextField
 import {
   useService
 } from '../../../hooks';
+
+import {
+  isIdValid
+} from '../utils/ValidationUtil';
 
 
 export default function IdProperty(props) {
@@ -28,12 +33,19 @@ export default function IdProperty(props) {
     return element.businessObject.id;
   };
 
+  const validate = (value) => {
+    const businessObject = getBusinessObject(element);
+
+    return isIdValid(businessObject, value, translate);
+  };
+
   return TextField({
     element,
     id: 'id',
     label: translate(is(element, 'bpmn:Participant') ? 'Participant ID' : 'ID'),
     getValue,
     setValue,
-    debounce
+    debounce,
+    validate
   });
 }

--- a/src/bpmn-properties-panel/provider/bpmn/properties/ProcessProps.js
+++ b/src/bpmn-properties-panel/provider/bpmn/properties/ProcessProps.js
@@ -1,9 +1,14 @@
 import { is } from 'bpmn-js/lib/util/ModelUtil';
+
 import TextField, { isEdited as textFieldIsEdited } from '../../../../properties-panel/components/entries/TextField';
 
 import {
   useService
 } from '../../../hooks';
+
+import {
+  isIdValid
+} from '../utils/ValidationUtil';
 
 
 export function ProcessProps(props) {
@@ -89,15 +94,23 @@ function ProcessId(props) {
     );
   };
 
+  const validate = (value) => {
+    return isIdValid(process, value, translate);
+  };
+
   return TextField({
     element,
     id: 'processId',
     label: translate('Process ID'),
     getValue,
     setValue,
-    debounce
+    debounce,
+    validate
   });
 }
+
+
+// helper ////////////////
 
 function hasProcessRef(element) {
   return is(element, 'bpmn:Participant') && element.businessObject.get('processRef');

--- a/src/bpmn-properties-panel/provider/bpmn/utils/ValidationUtil.js
+++ b/src/bpmn-properties-panel/provider/bpmn/utils/ValidationUtil.js
@@ -1,0 +1,51 @@
+const SPACE_REGEX = /\s/;
+
+// for QName validation as per http://www.w3.org/TR/REC-xml/#NT-NameChar
+const QNAME_REGEX = /^([a-z][\w-.]*:)?[a-z_][\w-.]*$/i;
+
+// for ID validation as per BPMN Schema (QName - Namespace)
+const ID_REGEX = /^[a-z_][\w-.]*$/i;
+
+/**
+ * checks whether the id value is valid
+ *
+ * @param {ModdleElement} element
+ * @param {String} idValue
+ * @param {Function} translate
+ *
+ * @return {String} error message
+ */
+export function isIdValid(element, idValue, translate) {
+  const assigned = element.$model.ids.assigned(idValue);
+  const idAlreadyExists = assigned && assigned !== element;
+
+  if (!idValue) {
+    return translate('ID must not be empty.');
+  }
+
+  if (idAlreadyExists) {
+    return translate('ID must be unique.');
+  }
+
+  return validateId(idValue, translate);
+}
+
+export function validateId(idValue, translate) {
+
+  if (containsSpace(idValue)) {
+    return translate('ID must not contain spaces.');
+  }
+
+  if (!ID_REGEX.test(idValue)) {
+
+    if (QNAME_REGEX.test(idValue)) {
+      return translate('ID must not contain prefix.');
+    }
+
+    return translate('ID must be a valid QName.');
+  }
+}
+
+export function containsSpace(value) {
+  return SPACE_REGEX.test(value);
+}

--- a/test/spec/bpmn-properties-panel/provider/bpmn/Id.bpmn
+++ b/test/spec/bpmn-properties-panel/provider/bpmn/Id.bpmn
@@ -2,11 +2,15 @@
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1f4yoyp" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
   <bpmn:process id="Process_1cd25ix" isExecutable="true">
     <bpmn:task id="Task_1" name="task" />
+    <bpmn:task id="Task_2" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1cd25ix">
       <bpmndi:BPMNShape id="Activity_0a9pl4k_di" bpmnElement="Task_1">
         <dc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_2_di" bpmnElement="Task_2">
+        <dc:Bounds x="160" y="190" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/bpmn-properties-panel/provider/bpmn/Id.spec.js
+++ b/test/spec/bpmn-properties-panel/provider/bpmn/Id.spec.js
@@ -110,6 +110,136 @@ describe('provider/bpmn - Id', function() {
       })
     );
 
+
+    describe('validation', function() {
+
+      it('should NOT remove id', inject(async function(elementRegistry, selection) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        await act(() => {
+          selection.select(task);
+        });
+
+        // when
+        const idInput = domQuery('input[name=id]', container);
+        changeInput(idInput, '');
+
+        // then
+        expect(getBusinessObject(task).get('id')).to.eql('Task_1');
+      }));
+
+
+      it('should NOT set existing id', inject(async function(elementRegistry, selection) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        await act(() => {
+          selection.select(task);
+        });
+
+        // when
+        const idInput = domQuery('input[name=id]', container);
+        changeInput(idInput, 'Task_2');
+
+        // then
+        expect(getBusinessObject(task).get('id')).to.eql('Task_1');
+      }));
+
+
+      it('should NOT set with spaces', inject(async function(elementRegistry, selection) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        await act(() => {
+          selection.select(task);
+        });
+
+        // when
+        const idInput = domQuery('input[name=id]', container);
+        changeInput(idInput, 'foo bar');
+
+        // then
+        expect(getBusinessObject(task).get('id')).to.eql('Task_1');
+      }));
+
+
+      it('should NOT set invalid QName', inject(async function(elementRegistry, selection) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        await act(() => {
+          selection.select(task);
+        });
+
+        // when
+        const idInput = domQuery('input[name=id]', container);
+        changeInput(idInput, '::foo');
+
+        // then
+        expect(getBusinessObject(task).get('id')).to.eql('Task_1');
+      }));
+
+
+      it('should NOT set prefix', inject(async function(elementRegistry, selection) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        await act(() => {
+          selection.select(task);
+        });
+
+        // when
+        const idInput = domQuery('input[name=id]', container);
+        changeInput(idInput, 'foo:Task_1');
+
+        // then
+        expect(getBusinessObject(task).get('id')).to.eql('Task_1');
+      }));
+
+
+      it('should NOT set invalid HTML characters', inject(async function(elementRegistry, selection) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        await act(() => {
+          selection.select(task);
+        });
+
+        // when
+        const idInput = domQuery('input[name=id]', container);
+        changeInput(idInput, '<foo>');
+
+        // then
+        expect(getBusinessObject(task).get('id')).to.eql('Task_1');
+      }));
+
+
+      it('should NOT set expression', inject(async function(elementRegistry, selection) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        await act(() => {
+          selection.select(task);
+        });
+
+        // when
+        const idInput = domQuery('input[name=id]', container);
+        changeInput(idInput, '${foo}');
+
+        // then
+        expect(getBusinessObject(task).get('id')).to.eql('Task_1');
+      }));
+
+    });
+
   });
 
 });

--- a/test/spec/bpmn-properties-panel/provider/bpmn/ProcessProps.spec.js
+++ b/test/spec/bpmn-properties-panel/provider/bpmn/ProcessProps.spec.js
@@ -205,11 +205,144 @@ describe('provider/bpmn - ProcessProps', function() {
         expect(processIdInput.value).to.eql(originalValue);
       })
     );
+
+
+    describe('validation', function() {
+
+      it('should NOT remove id', inject(async function(elementRegistry, selection) {
+
+        // given
+        const participant = elementRegistry.get('Participant_1');
+
+        await act(() => {
+          selection.select(participant);
+        });
+
+        // when
+        const processIdInput = domQuery('input[name=processId]', container);
+        changeInput(processIdInput, '');
+
+        // then
+        expect(getProcess(participant).get('id')).to.eql('Process_2');
+      }));
+
+
+      it('should NOT set existing id', inject(async function(elementRegistry, selection) {
+
+        // given
+        const participant = elementRegistry.get('Participant_1');
+
+        await act(() => {
+          selection.select(participant);
+        });
+
+        // when
+        const processIdInput = domQuery('input[name=processId]', container);
+        changeInput(processIdInput, 'Process_1');
+
+        // then
+        expect(getProcess(participant).get('id')).to.eql('Process_2');
+      }));
+
+
+      it('should NOT set with spaces', inject(async function(elementRegistry, selection) {
+
+        // given
+        const participant = elementRegistry.get('Participant_1');
+
+        await act(() => {
+          selection.select(participant);
+        });
+
+        // when
+        const processIdInput = domQuery('input[name=processId]', container);
+        changeInput(processIdInput, 'foo bar');
+
+        // then
+        expect(getProcess(participant).get('id')).to.eql('Process_2');
+      }));
+
+
+      it('should NOT set invalid QName', inject(async function(elementRegistry, selection) {
+
+        // given
+        const participant = elementRegistry.get('Participant_1');
+
+        await act(() => {
+          selection.select(participant);
+        });
+
+        // when
+        const processIdInput = domQuery('input[name=processId]', container);
+        changeInput(processIdInput, '::foo');
+
+        // then
+        expect(getProcess(participant).get('id')).to.eql('Process_2');
+      }));
+
+
+      it('should NOT set prefix', inject(async function(elementRegistry, selection) {
+
+        // given
+        const participant = elementRegistry.get('Participant_1');
+
+        await act(() => {
+          selection.select(participant);
+        });
+
+        // when
+        const processIdInput = domQuery('input[name=processId]', container);
+        changeInput(processIdInput, 'foo:Process_2');
+
+        // then
+        expect(getProcess(participant).get('id')).to.eql('Process_2');
+      }));
+
+
+      it('should NOT set invalid HTML characters', inject(async function(elementRegistry, selection) {
+
+        // given
+        const participant = elementRegistry.get('Participant_1');
+
+        await act(() => {
+          selection.select(participant);
+        });
+
+        // when
+        const processIdInput = domQuery('input[name=processId]', container);
+        changeInput(processIdInput, '<foo>');
+
+        // then
+        expect(getProcess(participant).get('id')).to.eql('Process_2');
+      }));
+
+
+      it('should NOT set expression', inject(async function(elementRegistry, selection) {
+
+        // given
+        const participant = elementRegistry.get('Participant_1');
+
+        await act(() => {
+          selection.select(participant);
+        });
+
+        // when
+        const processIdInput = domQuery('input[name=processId]', container);
+        changeInput(processIdInput, '${foo}');
+
+        // then
+        expect(getProcess(participant).get('id')).to.eql('Process_2');
+      }));
+
+    });
+
   });
+
 });
 
 
 // helper //////////////////
+
 function getProcess(participant) {
   return getBusinessObject(participant).get('processRef');
 }

--- a/test/spec/properties-panel/components/TextField.spec.js
+++ b/test/spec/properties-panel/components/TextField.spec.js
@@ -5,6 +5,7 @@ import {
 import TestContainer from 'mocha-test-container-support';
 
 import {
+  classes as domClasses,
   query as domQuery
 } from 'min-dom';
 
@@ -107,6 +108,102 @@ describe('<TextField>', function() {
 
   });
 
+
+  describe('validation', function() {
+
+    it('should set valid', function() {
+
+      // given
+      const validate = (v) => {
+        if (v === 'bar') {
+          return 'error';
+        }
+      };
+
+      const result = createTextField({ container, validate });
+
+      const entry = domQuery('.bio-properties-panel-entry', result.container);
+
+      const input = domQuery('.bio-properties-panel-input', entry);
+
+      // when
+      changeInput(input, 'foo');
+
+      // then
+      expect(isValid(entry)).to.be.true;
+    });
+
+
+    it('should set invalid', function() {
+
+      // given
+      const validate = (v) => {
+        if (v === 'bar') {
+          return 'error';
+        }
+      };
+
+      const result = createTextField({ container, validate });
+
+      const entry = domQuery('.bio-properties-panel-entry', result.container);
+      const input = domQuery('.bio-properties-panel-input', entry);
+
+      // when
+      changeInput(input, 'bar');
+
+      // then
+      expect(isValid(entry)).to.be.false;
+    });
+
+
+    it('should keep showing invalid value', function() {
+
+      // given
+      const validate = (v) => {
+        if (v === 'bar') {
+          return 'error';
+        }
+      };
+
+      const result = createTextField({ container, validate });
+
+      const entry = domQuery('.bio-properties-panel-entry', result.container);
+      const input = domQuery('.bio-properties-panel-input', entry);
+
+      // when
+      changeInput(input, 'bar');
+
+      // then
+      expect(input.value).to.eql('bar');
+    });
+
+
+    it('should show error message', function() {
+
+      // given
+      const validate = (v) => {
+        if (v === 'bar') {
+          return 'error';
+        }
+      };
+
+      const result = createTextField({ container, validate });
+
+      const entry = domQuery('.bio-properties-panel-entry', result.container);
+      const input = domQuery('.bio-properties-panel-input', entry);
+
+      // when
+      changeInput(input, 'bar');
+
+      const error = domQuery('.bio-properties-panel-error', entry);
+
+      // then
+      expect(error).to.exist;
+      expect(error.innerText).to.eql('error');
+    });
+
+  });
+
 });
 
 
@@ -121,6 +218,7 @@ function createTextField(options = {}) {
     label,
     getValue = noop,
     setValue = noop,
+    validate = noop,
     container
   } = options;
 
@@ -132,9 +230,14 @@ function createTextField(options = {}) {
       description={ description }
       getValue={ getValue }
       setValue={ setValue }
-      debounce={ debounce } />,
+      debounce={ debounce }
+      validate={ validate } />,
     {
       container
     }
   );
+}
+
+function isValid(node) {
+  return !domClasses(node).has('has-error');
 }


### PR DESCRIPTION
Closes #27 

* adds validation for ids
* adds basic validation styling (cf. [styles from Zeplin](https://app.zeplin.io/project/5e149dc7ef8eaa51b52af327/screen/60d9619fbeb59812106abf00))

Note: I was thinking about adding validation as a general concern for each entry type, but since we currently only validate this particular property and will add [linting as the general validation feature](https://github.com/camunda/camunda-modeler-design/issues/14), I decided to keep it simple and only support it for text fields for now. We can easily add validation for more entry types later.

![image](https://user-images.githubusercontent.com/9433996/124091916-9b270380-da56-11eb-8ffd-2afcc23ac748.png)